### PR TITLE
Refactor/extract heaviside functionality & add unit tests

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -66,3 +66,12 @@ def test_ancillary_files_no_support():
 
         with pytest.raises(NotImplementedError):
             um2nc.process("fake_infile", "fake_outfile", args=None)
+
+
+def test_stashcode_to_item_code_conversion():
+    m_stashcode = mock.Mock()
+    m_stashcode.section = 30
+    m_stashcode.item = 255
+
+    result = um2nc.to_item_code(m_stashcode)
+    assert result == 30255

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -77,12 +77,6 @@ def test_stash_code_to_item_code_conversion():
     assert result == 30255
 
 
-def mock_dict(d):
-    m = mock.MagicMock()
-    m.__getitem__.side_effect = d.__getitem__
-    return m
-
-
 def test_check_pressure_level_masking_need_heaviside_uv():
     ua_plev_cube = object()
     heaviside_uv_cube = object()

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -68,10 +68,10 @@ def test_ancillary_files_no_support():
             um2nc.process("fake_infile", "fake_outfile", args=None)
 
 
-def test_stashcode_to_item_code_conversion():
-    m_stashcode = mock.Mock()
-    m_stashcode.section = 30
-    m_stashcode.item = 255
+def test_stash_code_to_item_code_conversion():
+    m_stash_code = mock.Mock()
+    m_stash_code.section = 30
+    m_stash_code.item = 255
 
-    result = um2nc.to_item_code(m_stashcode)
+    result = um2nc.to_item_code(m_stash_code)
     assert result == 30255

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -77,14 +77,22 @@ def test_stash_code_to_item_code_conversion():
     assert result == 30255
 
 
+class DummyCube:
+    """
+    Imitation iris Cube for unit testing.
+    """
+
+    def __init__(self, attributes=None):
+        self.attributes = attributes
+
+
 def test_check_pressure_level_masking_need_heaviside_uv():
-    ua_plev_cube = object()
-    heaviside_uv_cube = object()
-    cube_index = {30201: ua_plev_cube,
-                  30301: heaviside_uv_cube}
+    ua_plev_cube = DummyCube({um2nc.ITEM_CODE: 30201})
+    heaviside_uv_cube = DummyCube({um2nc.ITEM_CODE: 30301})
+    cubes = [ua_plev_cube, heaviside_uv_cube]
 
     (need_heaviside_uv, heaviside_uv,
-     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cube_index)
+     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_uv
     assert heaviside_uv
@@ -93,23 +101,23 @@ def test_check_pressure_level_masking_need_heaviside_uv():
 
 
 def test_check_pressure_level_masking_missing_heaviside_uv():
-    ua_plev_cube = object()
-    cube_index = {30201: ua_plev_cube}
+    ua_plev_cube = DummyCube({um2nc.ITEM_CODE: 30201})
+    cubes = [ua_plev_cube]
 
-    need_heaviside_uv, heaviside_uv, _, _ = um2nc.check_pressure_level_masking(cube_index)
+    need_heaviside_uv, heaviside_uv, _, _ = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_uv
     assert heaviside_uv is None
 
 
 def test_check_pressure_level_masking_need_heaviside_t():
-    ta_plev_cube = object()
-    heaviside_t_cube = object()
-    cube_index = {30294: ta_plev_cube,
-                  30304: heaviside_t_cube}
+    ta_plev_cube = DummyCube({um2nc.ITEM_CODE: 30294})
+    heaviside_t_cube = DummyCube({um2nc.ITEM_CODE: 30304})
+
+    cubes = (ta_plev_cube, heaviside_t_cube)
 
     (need_heaviside_uv, heaviside_uv,
-     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cube_index)
+     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_uv is False
     assert heaviside_uv is None
@@ -118,10 +126,10 @@ def test_check_pressure_level_masking_need_heaviside_t():
 
 
 def test_check_pressure_level_masking_missing_heaviside_t():
-    ta_plev_cube = object()
-    cube_index = {30294: ta_plev_cube}
+    ta_plev_cube = DummyCube({um2nc.ITEM_CODE: 30294})
+    cubes = (ta_plev_cube, )
 
-    _, _, need_heaviside_t, heaviside_t = um2nc.check_pressure_level_masking(cube_index)
+    _, _, need_heaviside_t, heaviside_t = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_t
     assert heaviside_t is None

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -84,19 +84,30 @@ def mock_dict(d):
 
 
 def test_check_pressure_level_masking_need_heaviside_uv():
-    # NB: this mock setup is not ideal
-    m_stash_code = mock.MagicMock()
-    m_stash_code.section = 30
-    m_stash_code.item = 201
+    ua_plev_cube = object()
+    heaviside_uv_cube = object()
+    cube_index = {30201: ua_plev_cube,
+                  30301: heaviside_uv_cube}
 
-    m_heaviside_uv_cube = mock.Mock()
-    m_heaviside_uv_cube.attributes = mock_dict({"STASH": m_stash_code})
-
-    cubes = (m_heaviside_uv_cube, )
-
-    (need_heaviside_uv, have_heaviside_uv, heaviside_uv,
-     need_heaviside_t, have_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cubes)
+    (need_heaviside_uv, heaviside_uv,
+     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cube_index)
 
     assert need_heaviside_uv
-    assert have_heaviside_uv is False
+    assert heaviside_uv
+    assert need_heaviside_t is False
+    assert heaviside_t is None
+
+
+def test_check_pressure_level_masking_need_heaviside_t():
+    ta_plev_cube = object()
+    heaviside_t_cube = object()
+    cube_index = {30294: ta_plev_cube,
+                  30304: heaviside_t_cube}
+
+    (need_heaviside_uv, heaviside_uv,
+     need_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cube_index)
+
+    assert need_heaviside_uv is False
     assert heaviside_uv is None
+    assert need_heaviside_t
+    assert heaviside_t

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -92,6 +92,16 @@ def test_check_pressure_level_masking_need_heaviside_uv():
     assert heaviside_t is None
 
 
+def test_check_pressure_level_masking_missing_heaviside_uv():
+    ua_plev_cube = object()
+    cube_index = {30201: ua_plev_cube}
+
+    need_heaviside_uv, heaviside_uv, _, _ = um2nc.check_pressure_level_masking(cube_index)
+
+    assert need_heaviside_uv
+    assert heaviside_uv is None
+
+
 def test_check_pressure_level_masking_need_heaviside_t():
     ta_plev_cube = object()
     heaviside_t_cube = object()
@@ -105,3 +115,13 @@ def test_check_pressure_level_masking_need_heaviside_t():
     assert heaviside_uv is None
     assert need_heaviside_t
     assert heaviside_t
+
+
+def test_check_pressure_level_masking_missing_heaviside_t():
+    ta_plev_cube = object()
+    cube_index = {30294: ta_plev_cube}
+
+    _, _, need_heaviside_t, heaviside_t = um2nc.check_pressure_level_masking(cube_index)
+
+    assert need_heaviside_t
+    assert heaviside_t is None

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -75,3 +75,28 @@ def test_stash_code_to_item_code_conversion():
 
     result = um2nc.to_item_code(m_stash_code)
     assert result == 30255
+
+
+def mock_dict(d):
+    m = mock.MagicMock()
+    m.__getitem__.side_effect = d.__getitem__
+    return m
+
+
+def test_check_pressure_level_masking_need_heaviside_uv():
+    # NB: this mock setup is not ideal
+    m_stash_code = mock.MagicMock()
+    m_stash_code.section = 30
+    m_stash_code.item = 201
+
+    m_heaviside_uv_cube = mock.Mock()
+    m_heaviside_uv_cube.attributes = mock_dict({"STASH": m_stash_code})
+
+    cubes = (m_heaviside_uv_cube, )
+
+    (need_heaviside_uv, have_heaviside_uv, heaviside_uv,
+     need_heaviside_t, have_heaviside_t, heaviside_t) = um2nc.check_pressure_level_masking(cubes)
+
+    assert need_heaviside_uv
+    assert have_heaviside_uv is False
+    assert heaviside_uv is None

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -307,10 +307,10 @@ def process(infile, outfile, args):
 
     cubes = iris.load(infile)
     cubes.sort(key=lambda cs: cs.attributes['STASH'])
-    cube_index = {to_item_code(c.attributes['STASH']): c for c in cubes}
+    cube_lookup = {to_item_code(c.attributes['STASH']): c for c in cubes}
 
     (need_heaviside_uv, heaviside_uv,
-     need_heaviside_t, heaviside_t) = check_pressure_level_masking(cube_index)
+     need_heaviside_t, heaviside_t) = check_pressure_level_masking(cube_lookup)
 
     do_mask = not args.nomask  # make warning logic more readable
 
@@ -507,13 +507,13 @@ def to_item_code(stash_code):
     return 1000 * stash_code.section + stash_code.item
 
 
-def check_pressure_level_masking(cube_index):
+def check_pressure_level_masking(cube_lookup):
     """
     Examines cubes for heaviside uv/t pressure level masking components.
 
     Parameters
     ----------
-    cube_index : dict style mapping of integer item codes to corresponding iris Cube objects.
+    cube_lookup : dict style mapping of integer item codes to corresponding iris Cube objects.
 
     Returns
     -------
@@ -528,18 +528,18 @@ def check_pressure_level_masking(cube_index):
     heaviside_t = None
 
     # NB: can this be done with key existence tests?
-    for item_code, c in cube_index.items():
+    for item_code, cube in cube_lookup.items():
         if require_heaviside_uv(item_code):
             need_heaviside_uv = True
 
         if is_heaviside_uv(item_code):
-            heaviside_uv = c
+            heaviside_uv = cube
 
         if require_heaviside_t(item_code):
             need_heaviside_t = True
 
         if is_heaviside_t(item_code):
-            heaviside_t = c
+            heaviside_t = cube
 
     return need_heaviside_uv, heaviside_uv, need_heaviside_t, heaviside_t
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -502,7 +502,7 @@ def get_z_sea_constants(ff):
 
 def to_item_code(stash_code):
     """
-    Returns a stash code (with section and item members) as a combined integer "code".
+    Returns stash code (with section & item members) as a single integer "code".
 
     Parameters
     ----------
@@ -529,8 +529,9 @@ def check_pressure_level_masking(cubes):
             need_heaviside_t [bool], heaviside_t [iris cube or None])
 
     """
-    # Check whether there are any pressure level fields that should be masked. Can use temperature
-    # to mask instantaneous fields, so really should check whether these are time means
+    # Check whether there are any pressure level fields that should be masked.
+    # Can use temperature to mask instantaneous fields, so really should check
+    # whether these are time means
     need_heaviside_uv = need_heaviside_t = False
     heaviside_uv = None
     heaviside_t = None

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -490,19 +490,19 @@ def get_z_sea_constants(ff):
         raise NotImplementedError(msg) from err
 
 
-def to_item_code(stashcode):
+def to_item_code(stash_code):
     """
     Returns a stash code (with section and item members) as a combined integer "code".
 
     Parameters
     ----------
-    stashcode : TODO: find source, iris?
+    stash_code : TODO: find source, iris?
 
     Returns
     -------
     A single integer "item code".
     """
-    return 1000 * stashcode.section + stashcode.item
+    return 1000 * stash_code.section + stash_code.item
 
 
 def check_pressure_level_masking(cube_index):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -351,7 +351,7 @@ def process(infile, outfile, args):
 
         for c in cubes:
             stashcode = c.attributes['STASH']
-            itemcode = 1000*stashcode.section + stashcode.item
+            itemcode = to_item_code(stashcode)
 
             if args.include_list and itemcode not in args.include_list:
                 continue
@@ -510,6 +510,21 @@ def get_z_sea_constants(ff):
     except AttributeError as err:
         msg = f"Mule {type(ff)} file lacks z sea rho or theta. File type not yet supported."
         raise NotImplementedError(msg) from err
+
+
+def to_item_code(stashcode):
+    """
+    Returns a stash code (with section and item members) as a combined integer "code".
+
+    Parameters
+    ----------
+    stashcode : TODO: find source, iris?
+
+    Returns
+    -------
+    A single integer "item code".
+    """
+    return 1000 * stashcode.section + stashcode.item
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -313,8 +313,10 @@ def process(infile, outfile, args):
      need_heaviside_t, heaviside_t) = check_pressure_level_masking(cube_index)
 
     do_mask = not args.nomask  # make warning logic more readable
-    check_pressure_warnings(do_mask, need_heaviside_uv,  # TODO; fix name
-                            heaviside_uv, need_heaviside_t, heaviside_t)
+
+    if do_mask:
+        check_pressure_warnings(need_heaviside_uv, heaviside_uv,  # TODO; fix name
+                                need_heaviside_t, heaviside_t)
 
     nc_formats = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
                   3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
@@ -549,12 +551,22 @@ def is_heaviside_t(item_code):
     return item_code == 30304
 
 
-def check_pressure_warnings(do_mask, need_heaviside_uv, heaviside_uv, need_heaviside_t, heaviside_t):
-    if do_mask and need_heaviside_uv and heaviside_uv is None:
+def check_pressure_warnings(need_heaviside_uv, heaviside_uv, need_heaviside_t, heaviside_t):
+    """
+    Prints warnings if either of heaviside uv/t are required and not present.
+
+    Parameters
+    ----------
+    need_heaviside_uv : (bool)
+    heaviside_uv : iris Cube or None
+    need_heaviside_t : (bool)
+    heaviside_t : iris Cube or None
+    """
+    if need_heaviside_uv and heaviside_uv is None:
         print("Warning: heaviside_uv field needed for masking pressure level data is not present. "
               "These fields will be skipped")
 
-    if do_mask and need_heaviside_t and heaviside_t is None:
+    if need_heaviside_t and heaviside_t is None:
         print("Warning: heaviside_t field needed for masking pressure level data is not present. "
               "These fields will be skipped")
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -508,6 +508,19 @@ def to_item_code(stash_code):
 
 
 def check_pressure_level_masking(cube_index):
+    """
+    Examines cubes for heaviside uv/t pressure level masking components.
+
+    Parameters
+    ----------
+    cube_index : dict style mapping of integer item codes to corresponding iris Cube objects.
+
+    Returns
+    -------
+    Tuple: (need_heaviside_uv [bool], heaviside_uv [iris cube or None],
+            need_heaviside_t [bool], heaviside_t [iris cube or None])
+
+    """
     # Check whether there are any pressure level fields that should be masked. Can use temperature
     # to mask instantaneous fields, so really should check whether these are time means
     need_heaviside_uv = need_heaviside_t = False

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -326,12 +326,16 @@ def process(infile, outfile, args):
         check_pressure_warnings(need_heaviside_uv, heaviside_uv,
                                 need_heaviside_t, heaviside_t)
 
+    # TODO: can NC type be a single arg?
+    #       defer to new process() API
     nc_formats = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
                   3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
 
     with iris.fileformats.netcdf.Saver(outfile, nc_formats[args.nckind]) as sman:
         # Add global attributes
         if not args.nohist:
+            # TODO: fix program name
+            # TODO: update string formatting
             history = "File %s converted with um2netcdf_iris.py v2.1 at %s" % \
                       (infile, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
             sman.update_global_attributes({'history': history})

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -28,7 +28,7 @@ from iris.coords import CellMethod
 from iris.fileformats.pp import PPField
 
 
-# cube attribute names
+# Iris cube attribute names
 STASH = "STASH"
 ITEM_CODE = "item_code"
 
@@ -322,7 +322,8 @@ def process(infile, outfile, args):
     do_mask = not args.nomask  # make warning logic more readable
 
     if do_mask:
-        check_pressure_warnings(need_heaviside_uv, heaviside_uv,  # TODO: fix name
+        # TODO: rename func to better name
+        check_pressure_warnings(need_heaviside_uv, heaviside_uv,
                                 need_heaviside_t, heaviside_t)
 
     nc_formats = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
@@ -336,7 +337,7 @@ def process(infile, outfile, args):
             sman.update_global_attributes({'history': history})
         sman.update_global_attributes({'Conventions': 'CF-1.6'})
 
-        for c in cubes:  # TODO: use cube_index here
+        for c in cubes:  # TODO: use new cube item code attr
             stashcode = c.attributes['STASH']
             itemcode = to_item_code(stashcode)
 
@@ -534,7 +535,6 @@ def check_pressure_level_masking(cubes):
     heaviside_uv = None
     heaviside_t = None
 
-    # NB: can this be done with key existence tests?
     for cube in cubes:
         item_code = cube.attributes[ITEM_CODE]
 


### PR DESCRIPTION
Fixes #34.

This change extracts heaviside pressure masking functionality to separate functions. I had to refactor & shrink the old logic to facilitate unit testing (otherwise hacky mocking code was required). I've also added a `cube_lookup` to begin simplifying cube ops in `process()` and making the workflow more pythonic.

Known gaps :
* Magic numbers
* Some vars/funcs need good names (some naming changes are "open" should someone think something)
* `process()` still lacks a test


For the review, any opinions on the restructure, gaps & logic correctness comments are welcome.