### PR TITLE
Fix heaviside test regression

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -82,13 +82,28 @@ class DummyCube:
     Imitation iris Cube for unit testing.
     """
 
-    def __init__(self, attributes=None):
+    def __init__(self, item_code, attributes=None):
+        self.item_code = item_code
         self.attributes = attributes
 
 
-def test_check_pressure_level_masking_need_heaviside_uv():
-    ua_plev_cube = DummyCube({um2nc.ITEM_CODE: 30201})
-    heaviside_uv_cube = DummyCube({um2nc.ITEM_CODE: 30301})
+@pytest.fixture
+def ua_plev_cube():
+    return DummyCube(30201)
+
+
+@pytest.fixture
+def heaviside_uv_cube():
+    return DummyCube(30301)
+
+
+@pytest.fixture
+def ta_plev_cube():
+    return DummyCube(30294)
+
+
+def test_check_pressure_level_masking_need_heaviside_uv(ua_plev_cube,
+                                                        heaviside_uv_cube):
     cubes = [ua_plev_cube, heaviside_uv_cube]
 
     (need_heaviside_uv, heaviside_uv,
@@ -100,20 +115,16 @@ def test_check_pressure_level_masking_need_heaviside_uv():
     assert heaviside_t is None
 
 
-def test_check_pressure_level_masking_missing_heaviside_uv():
-    ua_plev_cube = DummyCube({um2nc.ITEM_CODE: 30201})
+def test_check_pressure_level_masking_missing_heaviside_uv(ua_plev_cube):
     cubes = [ua_plev_cube]
-
     need_heaviside_uv, heaviside_uv, _, _ = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_uv
     assert heaviside_uv is None
 
 
-def test_check_pressure_level_masking_need_heaviside_t():
-    ta_plev_cube = DummyCube({um2nc.ITEM_CODE: 30294})
-    heaviside_t_cube = DummyCube({um2nc.ITEM_CODE: 30304})
-
+def test_check_pressure_level_masking_need_heaviside_t(ta_plev_cube):
+    heaviside_t_cube = DummyCube(30304)
     cubes = (ta_plev_cube, heaviside_t_cube)
 
     (need_heaviside_uv, heaviside_uv,
@@ -125,10 +136,8 @@ def test_check_pressure_level_masking_need_heaviside_t():
     assert heaviside_t
 
 
-def test_check_pressure_level_masking_missing_heaviside_t():
-    ta_plev_cube = DummyCube({um2nc.ITEM_CODE: 30294})
+def test_check_pressure_level_masking_missing_heaviside_t(ta_plev_cube):
     cubes = (ta_plev_cube, )
-
     _, _, need_heaviside_t, heaviside_t = um2nc.check_pressure_level_masking(cubes)
 
     assert need_heaviside_t

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -310,17 +310,7 @@ def process(infile, outfile, args):
         raise Exception("Error: include list and exclude list are mutually exclusive")
 
     cubes = iris.load(infile)
-
-    for cube in cubes:
-        item_code = to_item_code(cube.attributes[STASH])
-
-        # hack: manually store item_code in cubes
-        if hasattr(cube, ITEM_CODE):
-            msg = f"Cube {item_code} already has 'item_code' attr"
-            raise NotImplementedError(msg)
-
-        setattr(cube, ITEM_CODE, item_code)
-
+    set_item_codes(cubes)
     cubes.sort(key=lambda cs: cs.item_code)
 
     (need_heaviside_uv, heaviside_uv,
@@ -524,6 +514,17 @@ def to_item_code(stash_code):
     A single integer "item code".
     """
     return 1000 * stash_code.section + stash_code.item
+
+
+def set_item_codes(cubes):
+    for cube in cubes:
+        if hasattr(cube, ITEM_CODE):
+            msg = f"Cube {cube.var_name} already has 'item_code' attribute"
+            raise NotImplementedError(msg)
+
+        # hack: manually store item_code in cubes
+        item_code = to_item_code(cube.attributes[STASH])
+        setattr(cube, ITEM_CODE, item_code)
 
 
 def check_pressure_level_masking(cubes):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -338,16 +338,15 @@ def process(infile, outfile, args):
             sman.update_global_attributes({'history': history})
         sman.update_global_attributes({'Conventions': 'CF-1.6'})
 
-        for c in cubes:  # TODO: use new cube item code attr
+        for c in cubes:
             stashcode = c.attributes['STASH']
-            itemcode = to_item_code(stashcode)
 
             if args.include_list and c.item_code not in args.include_list:
                 continue
             if args.exclude_list and c.item_code in args.exclude_list:
                 continue
 
-            umvar = stashvar.StashVar(itemcode)
+            umvar = stashvar.StashVar(c.item_code)
 
             if args.simple:
                 c.var_name = 'fld_s%2.2di%3.3d' % (stashcode.section, stashcode.item)
@@ -429,7 +428,7 @@ def process(infile, outfile, args):
                     continue
 
             if args.verbose:
-                print(c.name(), itemcode)
+                print(c.name(), c.item_code)
 
             cubewrite(c, sman, args.compression, args.use64bit, args.verbose)
 


### PR DESCRIPTION
Relates to #34.

The original solution added custom records to `cube` _global attributes_. These were written to `NetCDF` _global attributes_, "breaking" the compatibility of testing outputs. This solution introduces a slight hack, dynamically adding `item_code` as an attribute of each `cube` instead of in the `attributes` dict.

I've manually confirmed running `um2nc` no longer includes additional global vars.