### PR TITLE
Extract history function

### DIFF
--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -10,9 +10,11 @@ Note that um2netcdf depends on the following data access libraries:
 * Iris https://github.com/SciTools/iris
 """
 
+import os
 import sys
 import argparse
 import datetime
+import warnings
 
 from umpost import stashvar_cmip6 as stashvar
 
@@ -331,11 +333,8 @@ def process(infile, outfile, args):
     with iris.fileformats.netcdf.Saver(outfile, nc_formats[args.nckind]) as sman:
         # Add global attributes
         if not args.nohist:
-            # TODO: fix program name
-            # TODO: update string formatting
-            history = "File %s converted with um2netcdf_iris.py v2.1 at %s" % \
-                      (infile, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-            sman.update_global_attributes({'history': history})
+            add_global_history(infile, sman)
+
         sman.update_global_attributes({'Conventions': 'CF-1.6'})
 
         for c in cubes:
@@ -601,6 +600,16 @@ def check_pressure_warnings(need_heaviside_uv, heaviside_uv, need_heaviside_t, h
     if need_heaviside_t and heaviside_t is None:
         print("Warning: heaviside_t field needed for masking pressure level data is not present. "
               "These fields will be skipped")
+
+
+def add_global_history(infile, iris_out):
+    version = -1  # FIXME: determine version
+    t = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    um2nc_path = os.path.abspath(__file__)
+    history = f"File {infile} converted with {um2nc_path} {version} at {t}"
+
+    iris_out.update_global_attributes({'history': history})
+    warnings.warn("um2nc version number not specified!")
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -331,6 +331,8 @@ def process(infile, outfile, args):
                   3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
 
     with iris.fileformats.netcdf.Saver(outfile, nc_formats[args.nckind]) as sman:
+        # TODO: move attribute mods to end of process() to group sman ops
+        #       do when sman ops refactored into a write function
         # Add global attributes
         if not args.nohist:
             add_global_history(infile, sman)


### PR DESCRIPTION
Closes #42.

This PR extracts & updates the file history attribute. String formatting has been updated with modern Python, and the hard-coded filename has been removed.

Known problems:
* The new version number needs to be determined (the method should ideally be decided in this PR).