### PR TITLE
Extract cube var renaming code to functions

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -336,9 +336,12 @@ def test_add_missing_standard_name_from_um(x_wind_cube):
 
 
 def test_rename_cubes_long_name(x_wind_cube):
+    # ensure a cube without a long name is updated with the um long name
+    long_name = "long-name"
     x_wind_cube.long_name = ""
-    um_var = UMStash("long-name", "", "", "", "")
+    um_var = UMStash(long_name, "", "", "", "")
     um2nc.rename_cube_long_names(x_wind_cube, um_var)
+    assert x_wind_cube.long_name == long_name
 
 
 def test_rename_cubes_long_name_over_limit(x_wind_cube, empty_um_var):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -298,3 +298,18 @@ def test_rename_cube_standard_name_y_wind(um_var_empty_std):
 
     um2nc.rename_cube_names(fake_cube, um_var_empty_std, verbose=False)
     assert fake_cube.standard_name == "northward_wind"
+
+
+def test_standard_name_umvar_name_mismatch(x_wind_cube):
+    um_var = UMStash("", "", "", "fake", "")
+    um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
+    assert x_wind_cube.standard_name == um_var.standard_name
+
+
+def test_standard_name_umvar_name_mismatch_warn(x_wind_cube):
+    um_var = UMStash("", "", "", "fake", "")
+
+    with pytest.warns():
+        um2nc.rename_cube_names(x_wind_cube, um_var, verbose=True)
+
+    assert x_wind_cube.standard_name == um_var.standard_name

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -235,8 +235,8 @@ UMStash = namedtuple("UMStash",
 
 
 @pytest.fixture
-def um_var_empty_std():
-    """Return an empty um_var lookup."""
+def empty_um_var():
+    """Return an 'empty' um_var lookup where all names are empty strings."""
     um_var = UMStash("", "", "", "", "")
     return um_var
 
@@ -254,7 +254,7 @@ def min_cell_method():
     return CellMethod("minimum")
 
 
-def test_rename_cube_var_name_simple(x_wind_cube, um_var_empty_std):
+def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
     # NB: ignores cell methods functionality
     assert x_wind_cube.var_name == "var_name"  # dummy initial value
     um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
@@ -262,7 +262,7 @@ def test_rename_cube_var_name_simple(x_wind_cube, um_var_empty_std):
 
 
 def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
-                                                      um_var_empty_std,
+                                                      empty_um_var,
                                                       max_cell_method):
     x_wind_cube.cell_methods = [max_cell_method]
 
@@ -271,7 +271,7 @@ def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
 
 
 def test_rename_cube_var_rename_with_cell_methods_min(x_wind_cube,
-                                                      um_var_empty_std,
+                                                      empty_um_var,
                                                       min_cell_method):
     x_wind_cube.cell_methods = [min_cell_method]
 
@@ -287,20 +287,20 @@ def test_rename_cube_var_name_unique(x_wind_cube):
     assert x_wind_cube.var_name == unique
 
 
-def test_rename_cube_standard_name_x_wind(x_wind_cube, um_var_empty_std):
+def test_rename_cube_standard_name_x_wind(x_wind_cube, empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
-    um2nc.rename_cube_standard_names(x_wind_cube, um_var_empty_std, verbose=False)
+    um2nc.rename_cube_standard_names(x_wind_cube, empty_um_var, verbose=False)
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
-def test_rename_cube_standard_name_y_wind(um_var_empty_std):
+def test_rename_cube_standard_name_y_wind(empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
     m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
     m_cube.cell_methods = []
 
-    um2nc.rename_cube_standard_names(m_cube, um_var_empty_std, verbose=False)
+    um2nc.rename_cube_standard_names(m_cube, empty_um_var, verbose=False)
     assert m_cube.standard_name == "northward_wind"
 
 
@@ -337,10 +337,10 @@ def test_rename_cubes_long_name(x_wind_cube):
     um2nc.rename_cube_long_names(x_wind_cube, um_var)
 
 
-def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
+def test_rename_cubes_long_name_over_limit(x_wind_cube, empty_um_var):
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 
     x_wind_cube.standard_name = ""
-    um2nc.rename_cube_long_names(x_wind_cube, um_var_empty_std)
+    um2nc.rename_cube_long_names(x_wind_cube, empty_um_var)
     assert len(x_wind_cube.long_name) == um2nc.XCONV_LONG_NAME_LIMIT

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -263,7 +263,7 @@ def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
         assert x_wind_cube.var_name == "fld_s00i002", f"Failed with um_var={um_var}"
 
 
-def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
+def test_rename_cube_var_rename_cell_methods_adds_max(x_wind_cube,
                                                       empty_um_var,
                                                       max_cell_method):
     x_wind_cube.cell_methods = [max_cell_method]
@@ -273,7 +273,7 @@ def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
         assert x_wind_cube.var_name == "fld_s00i002_max"
 
 
-def test_rename_cube_var_rename_with_cell_methods_min(x_wind_cube,
+def test_rename_cube_var_rename_cell_methods_adds_min(x_wind_cube,
                                                       empty_um_var,
                                                       min_cell_method):
     x_wind_cube.cell_methods = [min_cell_method]

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -348,6 +348,20 @@ def test_rename_cube_long_name(x_wind_cube):
     assert x_wind_cube.long_name == long_name
 
 
+def test_rename_cube_long_name_missing_names_do_nothing(x_wind_cube, empty_um_var):
+    x_wind_cube.long_name = ""
+    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
+    assert x_wind_cube.long_name == ""
+
+
+def test_rename_cube_long_name_under_limit_do_nothing(x_wind_cube, empty_um_var):
+    name = "long-name-under-limit"
+    x_wind_cube.long_name = name
+    assert len(x_wind_cube.long_name) < um2nc.XCONV_LONG_NAME_LIMIT
+    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
+    assert x_wind_cube.long_name == name  # nothing should be replaced
+
+
 def test_rename_cube_long_name_over_limit(x_wind_cube, empty_um_var):
     # ensure character limit is enforced
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -254,118 +254,118 @@ def min_cell_method():
     return CellMethod("minimum")
 
 
-def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
+def test_fix_var_name_simple(x_wind_cube, empty_um_var):
     # NB: ignores cell methods functionality
     assert x_wind_cube.var_name == "var_name"  # dummy initial value
 
     for um_var in (None, empty_um_var):
-        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        um2nc.fix_var_name(x_wind_cube, um_var, simple=True)
         assert x_wind_cube.var_name == "fld_s00i002", f"Failed with um_var={um_var}"
 
 
-def test_rename_cube_var_name_cell_methods_adds_max(x_wind_cube,
+def test_fix_var_name_cell_methods_adds_max(x_wind_cube,
                                                     empty_um_var,
                                                     max_cell_method):
     # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [max_cell_method]
 
     for um_var in (None, empty_um_var):
-        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        um2nc.fix_var_name(x_wind_cube, um_var, simple=True)
         assert x_wind_cube.var_name == "fld_s00i002_max"
 
 
-def test_rename_cube_var_name_cell_methods_adds_min(x_wind_cube,
+def test_fix_var_name_cell_methods_adds_min(x_wind_cube,
                                                     empty_um_var,
                                                     min_cell_method):
     # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [min_cell_method]
 
     for um_var in (None, empty_um_var):
-        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        um2nc.fix_var_name(x_wind_cube, um_var, simple=True)
         assert x_wind_cube.var_name == "fld_s00i002_min"
 
 
-def test_rename_cube_var_name_unique(x_wind_cube):
+def test_fix_var_name_unique(x_wind_cube):
     # ensure um unique name given to cubes in non-simple mode
     # NB: ignores cell methods functionality
     unique = "unique_string_name"
     um_unique = UMStash("", "", "", "", unique)
-    um2nc.rename_cube_var_name(x_wind_cube, um_unique, simple=False)
+    um2nc.fix_var_name(x_wind_cube, um_unique, simple=False)
     assert x_wind_cube.var_name == unique
 
 
-def test_rename_cube_standard_name_update_x_wind(x_wind_cube, empty_um_var):
+def test_fix_standard_name_update_x_wind(x_wind_cube, empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
-    um2nc.rename_cube_standard_name(x_wind_cube, empty_um_var, verbose=False)
+    um2nc.fix_standard_name(x_wind_cube, empty_um_var, verbose=False)
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
-def test_rename_cube_standard_name_update_wind(empty_um_var):
+def test_fix_standard_name_update_wind(empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
     m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
     m_cube.cell_methods = []
 
-    um2nc.rename_cube_standard_name(m_cube, empty_um_var, verbose=False)
+    um2nc.fix_standard_name(m_cube, empty_um_var, verbose=False)
     assert m_cube.standard_name == "northward_wind"
 
 
-def test_rename_cube_standard_name_with_mismatch(x_wind_cube):
+def test_fix_standard_name_with_mismatch(x_wind_cube):
     # ensure mismatching standard names between cube & um uses the um std name
     um_var = UMStash("", "", "", "fake", "")
-    um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=False)
+    um2nc.fix_standard_name(x_wind_cube, um_var, verbose=False)
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_rename_cube_standard_name_with_mismatch_warn(x_wind_cube):
+def test_fix_standard_name_with_mismatch_warn(x_wind_cube):
     # as per standard name mismatch, ensuring a warning is raised
     um_var = UMStash("", "", "", "fake", "")
 
     with pytest.warns():
-        um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=True)
+        um2nc.fix_standard_name(x_wind_cube, um_var, verbose=True)
 
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_rename_cube_standard_name_add_missing_name_from_um(x_wind_cube):
+def test_fix_standard_name_add_missing_name_from_um(x_wind_cube):
     # ensure cubes without std name are renamed with the um standard name
     for std_name in ("", None):
         x_wind_cube.standard_name = std_name
         expected = "standard-name-slot"
         um_var = UMStash("", "", "", expected, "")
         assert um_var.standard_name == expected
-        um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=False)
+        um2nc.fix_standard_name(x_wind_cube, um_var, verbose=False)
         assert x_wind_cube.standard_name == expected
 
 
-def test_rename_cube_long_name(x_wind_cube):
+def test_fix_long_name(x_wind_cube):
     # ensure a cube without a long name is updated with the um long name
     long_name = "long-name"
     x_wind_cube.long_name = ""
     um_var = UMStash(long_name, "", "", "", "")
-    um2nc.rename_cube_long_name(x_wind_cube, um_var)
+    um2nc.fix_long_name(x_wind_cube, um_var)
     assert x_wind_cube.long_name == long_name
 
 
-def test_rename_cube_long_name_missing_names_do_nothing(x_wind_cube, empty_um_var):
+def test_fix_long_name_missing_names_do_nothing(x_wind_cube, empty_um_var):
     x_wind_cube.long_name = ""
-    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
+    um2nc.fix_long_name(x_wind_cube, empty_um_var)
     assert x_wind_cube.long_name == ""
 
 
-def test_rename_cube_long_name_under_limit_do_nothing(x_wind_cube, empty_um_var):
+def test_fix_long_name_under_limit_do_nothing(x_wind_cube, empty_um_var):
     name = "long-name-under-limit"
     x_wind_cube.long_name = name
     assert len(x_wind_cube.long_name) < um2nc.XCONV_LONG_NAME_LIMIT
-    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
+    um2nc.fix_long_name(x_wind_cube, empty_um_var)
     assert x_wind_cube.long_name == name  # nothing should be replaced
 
 
-def test_rename_cube_long_name_over_limit(x_wind_cube, empty_um_var):
+def test_fix_long_name_over_limit(x_wind_cube, empty_um_var):
     # ensure character limit is enforced
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 
-    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
+    um2nc.fix_long_name(x_wind_cube, empty_um_var)
     assert len(x_wind_cube.long_name) == um2nc.XCONV_LONG_NAME_LIMIT

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -338,12 +338,9 @@ def test_rename_cubes_long_name(x_wind_cube):
 
 
 def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
-    max_len = 110  # TODO: use constant
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
+    assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
+
     x_wind_cube.standard_name = ""
-    assert len(x_wind_cube.long_name) > max_len
     um2nc.rename_cube_long_names(x_wind_cube, um_var_empty_std)
-    assert len(x_wind_cube.long_name) == max_len
-
-
-
+    assert len(x_wind_cube.long_name) == um2nc.XCONV_LONG_NAME_LIMIT

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -328,3 +328,13 @@ def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
     assert len(x_wind_cube.long_name) > max_len
     um2nc.rename_cube_names(x_wind_cube, um_var_empty_std, verbose=False)
     assert len(x_wind_cube.long_name) == max_len
+
+
+def test_add_std_name_from_umvar_if_missing(x_wind_cube):
+    for std_name in ("", None):
+        x_wind_cube.standard_name = std_name
+        expected = "standard-name-slot"
+        um_var = UMStash("", "", "", expected, "")
+        assert um_var.standard_name == expected
+        um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
+        assert x_wind_cube.standard_name == expected

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -263,9 +263,9 @@ def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
         assert x_wind_cube.var_name == "fld_s00i002", f"Failed with um_var={um_var}"
 
 
-def test_rename_cube_var_rename_cell_methods_adds_max(x_wind_cube,
-                                                      empty_um_var,
-                                                      max_cell_method):
+def test_rename_cube_var_name_cell_methods_adds_max(x_wind_cube,
+                                                    empty_um_var,
+                                                    max_cell_method):
     # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [max_cell_method]
 
@@ -274,9 +274,9 @@ def test_rename_cube_var_rename_cell_methods_adds_max(x_wind_cube,
         assert x_wind_cube.var_name == "fld_s00i002_max"
 
 
-def test_rename_cube_var_rename_cell_methods_adds_min(x_wind_cube,
-                                                      empty_um_var,
-                                                      min_cell_method):
+def test_rename_cube_var_name_cell_methods_adds_min(x_wind_cube,
+                                                    empty_um_var,
+                                                    min_cell_method):
     # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [min_cell_method]
 
@@ -294,14 +294,14 @@ def test_rename_cube_var_name_unique(x_wind_cube):
     assert x_wind_cube.var_name == unique
 
 
-def test_rename_cube_standard_name_x_wind(x_wind_cube, empty_um_var):
+def test_rename_cube_standard_name_update_x_wind(x_wind_cube, empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
     um2nc.rename_cube_standard_name(x_wind_cube, empty_um_var, verbose=False)
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
-def test_rename_cube_standard_name_y_wind(empty_um_var):
+def test_rename_cube_standard_name_update_wind(empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
     m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
@@ -311,14 +311,14 @@ def test_rename_cube_standard_name_y_wind(empty_um_var):
     assert m_cube.standard_name == "northward_wind"
 
 
-def test_cube_um_standard_name_mismatch(x_wind_cube):
+def test_rename_cube_standard_name_with_mismatch(x_wind_cube):
     # ensure mismatching standard names between cube & um uses the um std name
     um_var = UMStash("", "", "", "fake", "")
     um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=False)
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_test_cube_um_standard_name_mismatch_warn(x_wind_cube):
+def test_rename_cube_standard_name_with_mismatch_warn(x_wind_cube):
     # as per standard name mismatch, ensuring a warning is raised
     um_var = UMStash("", "", "", "fake", "")
 
@@ -328,7 +328,7 @@ def test_test_cube_um_standard_name_mismatch_warn(x_wind_cube):
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_add_missing_standard_name_from_um(x_wind_cube):
+def test_rename_cube_standard_name_add_missing_name_from_um(x_wind_cube):
     # ensure cubes without std name are renamed with the um standard name
     for std_name in ("", None):
         x_wind_cube.standard_name = std_name
@@ -339,7 +339,7 @@ def test_add_missing_standard_name_from_um(x_wind_cube):
         assert x_wind_cube.standard_name == expected
 
 
-def test_rename_cubes_long_name(x_wind_cube):
+def test_rename_cube_long_name(x_wind_cube):
     # ensure a cube without a long name is updated with the um long name
     long_name = "long-name"
     x_wind_cube.long_name = ""
@@ -348,8 +348,8 @@ def test_rename_cubes_long_name(x_wind_cube):
     assert x_wind_cube.long_name == long_name
 
 
-def test_rename_cubes_long_name_over_limit(x_wind_cube, empty_um_var):
-    # ensure the 110 character limit is enforced
+def test_rename_cube_long_name_over_limit(x_wind_cube, empty_um_var):
+    # ensure character limit is enforced
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -241,13 +241,46 @@ def um_var_empty_std():
     return um_var
 
 
+CellMethod = namedtuple("CellMethod", "method")
+
+
+@pytest.fixture
+def max_cell_method():
+    return CellMethod("maximum")
+
+
+@pytest.fixture
+def min_cell_method():
+    return CellMethod("minimum")
+
+
 def test_rename_cube_var_name_simple(x_wind_cube, um_var_empty_std):
+    # NB: ignores cell methods functionality
     assert x_wind_cube.var_name == "var_name"  # dummy initial value
     um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
     assert x_wind_cube.var_name == "fld_s00i002"
 
 
+def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
+                                                      um_var_empty_std,
+                                                      max_cell_method):
+    x_wind_cube.cell_methods = [max_cell_method]
+
+    um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
+    assert x_wind_cube.var_name == "fld_s00i002_max"
+
+
+def test_rename_cube_var_rename_with_cell_methods_min(x_wind_cube,
+                                                      um_var_empty_std,
+                                                      min_cell_method):
+    x_wind_cube.cell_methods = [min_cell_method]
+
+    um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
+    assert x_wind_cube.var_name == "fld_s00i002_min"
+
+
 def test_rename_cube_var_name_unique(x_wind_cube):
+    # NB: ignores cell methods functionality
     unique = "unique_string_name"
     um_unique = UMStash("", "", "", "", unique)
     um2nc.rename_cube_var_name(x_wind_cube, um_unique, simple=False)

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -313,3 +313,18 @@ def test_standard_name_umvar_name_mismatch_warn(x_wind_cube):
         um2nc.rename_cube_names(x_wind_cube, um_var, verbose=True)
 
     assert x_wind_cube.standard_name == um_var.standard_name
+
+
+def test_rename_cubes_long_name(x_wind_cube):
+    x_wind_cube.long_name = ""
+    um_var = UMStash("long-name", "", "", "", "")
+    um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
+
+
+def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
+    max_len = 110
+    x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
+    x_wind_cube.standard_name = ""
+    assert len(x_wind_cube.long_name) > max_len
+    um2nc.rename_cube_names(x_wind_cube, um_var_empty_std, verbose=False)
+    assert len(x_wind_cube.long_name) == max_len

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -297,7 +297,7 @@ def test_rename_cube_var_name_unique(x_wind_cube):
 def test_rename_cube_standard_name_x_wind(x_wind_cube, empty_um_var):
     # test cube wind renaming block only
     # use empty um_var_empty_std to skip renaming logic
-    um2nc.rename_cube_standard_names(x_wind_cube, empty_um_var, verbose=False)
+    um2nc.rename_cube_standard_name(x_wind_cube, empty_um_var, verbose=False)
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
@@ -307,14 +307,14 @@ def test_rename_cube_standard_name_y_wind(empty_um_var):
     m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
     m_cube.cell_methods = []
 
-    um2nc.rename_cube_standard_names(m_cube, empty_um_var, verbose=False)
+    um2nc.rename_cube_standard_name(m_cube, empty_um_var, verbose=False)
     assert m_cube.standard_name == "northward_wind"
 
 
 def test_cube_um_standard_name_mismatch(x_wind_cube):
     # ensure mismatching standard names between cube & um uses the um std name
     um_var = UMStash("", "", "", "fake", "")
-    um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=False)
+    um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=False)
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
@@ -323,7 +323,7 @@ def test_test_cube_um_standard_name_mismatch_warn(x_wind_cube):
     um_var = UMStash("", "", "", "fake", "")
 
     with pytest.warns():
-        um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=True)
+        um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=True)
 
     assert x_wind_cube.standard_name == um_var.standard_name
 
@@ -335,7 +335,7 @@ def test_add_missing_standard_name_from_um(x_wind_cube):
         expected = "standard-name-slot"
         um_var = UMStash("", "", "", expected, "")
         assert um_var.standard_name == expected
-        um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=False)
+        um2nc.rename_cube_standard_name(x_wind_cube, um_var, verbose=False)
         assert x_wind_cube.standard_name == expected
 
 
@@ -344,7 +344,7 @@ def test_rename_cubes_long_name(x_wind_cube):
     long_name = "long-name"
     x_wind_cube.long_name = ""
     um_var = UMStash(long_name, "", "", "", "")
-    um2nc.rename_cube_long_names(x_wind_cube, um_var)
+    um2nc.rename_cube_long_name(x_wind_cube, um_var)
     assert x_wind_cube.long_name == long_name
 
 
@@ -354,5 +354,5 @@ def test_rename_cubes_long_name_over_limit(x_wind_cube, empty_um_var):
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 
     x_wind_cube.standard_name = ""
-    um2nc.rename_cube_long_names(x_wind_cube, empty_um_var)
+    um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
     assert len(x_wind_cube.long_name) == um2nc.XCONV_LONG_NAME_LIMIT

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -266,6 +266,7 @@ def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
 def test_rename_cube_var_rename_cell_methods_adds_max(x_wind_cube,
                                                       empty_um_var,
                                                       max_cell_method):
+    # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [max_cell_method]
 
     for um_var in (None, empty_um_var):
@@ -276,6 +277,7 @@ def test_rename_cube_var_rename_cell_methods_adds_max(x_wind_cube,
 def test_rename_cube_var_rename_cell_methods_adds_min(x_wind_cube,
                                                       empty_um_var,
                                                       min_cell_method):
+    # ensure maximum cell methods add suffix to cube name
     x_wind_cube.cell_methods = [min_cell_method]
 
     for um_var in (None, empty_um_var):
@@ -284,6 +286,7 @@ def test_rename_cube_var_rename_cell_methods_adds_min(x_wind_cube,
 
 
 def test_rename_cube_var_name_unique(x_wind_cube):
+    # ensure um unique name given to cubes in non-simple mode
     # NB: ignores cell methods functionality
     unique = "unique_string_name"
     um_unique = UMStash("", "", "", "", unique)
@@ -316,6 +319,7 @@ def test_cube_um_standard_name_mismatch(x_wind_cube):
 
 
 def test_test_cube_um_standard_name_mismatch_warn(x_wind_cube):
+    # as per standard name mismatch, ensuring a warning is raised
     um_var = UMStash("", "", "", "fake", "")
 
     with pytest.warns():
@@ -345,6 +349,7 @@ def test_rename_cubes_long_name(x_wind_cube):
 
 
 def test_rename_cubes_long_name_over_limit(x_wind_cube, empty_um_var):
+    # ensure the 110 character limit is enforced
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -251,7 +251,7 @@ def test_fix_var_name_simple(x_wind_cube):
     # NB: ignores cell methods functionality
     assert x_wind_cube.var_name == "var_name"  # dummy initial value
 
-    for unique in (None, ""):
+    for unique in (None, "", "fake"):  # fake ensures `simple=True` is selected before unique name
         um2nc.fix_var_name(x_wind_cube, unique, simple=True)
         assert x_wind_cube.var_name == "fld_s00i002", f"Failed with um_var={unique}"
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -289,7 +289,7 @@ def test_fix_standard_name_update_x_wind(x_wind_cube):
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
-def test_fix_standard_name_update_wind():
+def test_fix_standard_name_update_y_wind():
     # test cube wind renaming block only
     # use empty std name to bypass renaming logic
     m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
@@ -336,19 +336,24 @@ def test_fix_long_name(x_wind_cube):
 
 
 def test_fix_long_name_missing_names_do_nothing(x_wind_cube):
-    x_wind_cube.long_name = ""
+    # contrived test: this is a gap filler to ensure the cube is not updated if it lacks a long
+    # name & there is no long name to copy from the UM Stash codes. It's partially ensuring the
+    # process logic works with a range of "empty" values line None, zero len strs etc
+    empty_values = ("", None)
 
-    for um_long_name in ("", None):
+    for um_long_name in empty_values:
+        x_wind_cube.long_name = um_long_name
         um2nc.fix_long_name(x_wind_cube, um_long_name)
-        assert x_wind_cube.long_name == ""
+        assert x_wind_cube.long_name in empty_values
 
 
 def test_fix_long_name_under_limit_do_nothing(x_wind_cube):
+    # somewhat contrived test, ensure cube long name is retained if under the length limit
     long_name = "long-name-under-limit"
     x_wind_cube.long_name = long_name
     assert len(x_wind_cube.long_name) < um2nc.XCONV_LONG_NAME_LIMIT
 
-    for um_long_name in ("", None):
+    for um_long_name in ("", None, "fake"):
         um2nc.fix_long_name(x_wind_cube, um_long_name)
         assert x_wind_cube.long_name == long_name  # nothing should be replaced
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -353,6 +353,5 @@ def test_rename_cube_long_name_over_limit(x_wind_cube, empty_um_var):
     x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
     assert len(x_wind_cube.long_name) > um2nc.XCONV_LONG_NAME_LIMIT
 
-    x_wind_cube.standard_name = ""
     um2nc.rename_cube_long_name(x_wind_cube, empty_um_var)
     assert len(x_wind_cube.long_name) == um2nc.XCONV_LONG_NAME_LIMIT

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -288,53 +288,62 @@ def test_rename_cube_var_name_unique(x_wind_cube):
 
 
 def test_rename_cube_standard_name_x_wind(x_wind_cube, um_var_empty_std):
-    um2nc.rename_cube_names(x_wind_cube, um_var_empty_std, verbose=False)
+    # test cube wind renaming block only
+    # use empty um_var_empty_std to skip renaming logic
+    um2nc.rename_cube_standard_names(x_wind_cube, um_var_empty_std, verbose=False)
     assert x_wind_cube.standard_name == "eastward_wind"
 
 
 def test_rename_cube_standard_name_y_wind(um_var_empty_std):
-    fake_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
-    fake_cube.cell_methods = []
+    # test cube wind renaming block only
+    # use empty um_var_empty_std to skip renaming logic
+    m_cube = PartialCube("var_name", {'STASH': DummyStash(0, 3)}, "y_wind")
+    m_cube.cell_methods = []
 
-    um2nc.rename_cube_names(fake_cube, um_var_empty_std, verbose=False)
-    assert fake_cube.standard_name == "northward_wind"
+    um2nc.rename_cube_standard_names(m_cube, um_var_empty_std, verbose=False)
+    assert m_cube.standard_name == "northward_wind"
 
 
-def test_standard_name_umvar_name_mismatch(x_wind_cube):
+def test_cube_um_standard_name_mismatch(x_wind_cube):
+    # ensure mismatching standard names between cube & um uses the um std name
     um_var = UMStash("", "", "", "fake", "")
-    um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
+    um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=False)
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_standard_name_umvar_name_mismatch_warn(x_wind_cube):
+def test_test_cube_um_standard_name_mismatch_warn(x_wind_cube):
     um_var = UMStash("", "", "", "fake", "")
 
     with pytest.warns():
-        um2nc.rename_cube_names(x_wind_cube, um_var, verbose=True)
+        um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=True)
 
     assert x_wind_cube.standard_name == um_var.standard_name
 
 
-def test_rename_cubes_long_name(x_wind_cube):
-    x_wind_cube.long_name = ""
-    um_var = UMStash("long-name", "", "", "", "")
-    um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
-
-
-def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
-    max_len = 110
-    x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
-    x_wind_cube.standard_name = ""
-    assert len(x_wind_cube.long_name) > max_len
-    um2nc.rename_cube_names(x_wind_cube, um_var_empty_std, verbose=False)
-    assert len(x_wind_cube.long_name) == max_len
-
-
-def test_add_std_name_from_umvar_if_missing(x_wind_cube):
+def test_add_missing_standard_name_from_um(x_wind_cube):
+    # ensure cubes without std name are renamed with the um standard name
     for std_name in ("", None):
         x_wind_cube.standard_name = std_name
         expected = "standard-name-slot"
         um_var = UMStash("", "", "", expected, "")
         assert um_var.standard_name == expected
-        um2nc.rename_cube_names(x_wind_cube, um_var, verbose=False)
+        um2nc.rename_cube_standard_names(x_wind_cube, um_var, verbose=False)
         assert x_wind_cube.standard_name == expected
+
+
+def test_rename_cubes_long_name(x_wind_cube):
+    x_wind_cube.long_name = ""
+    um_var = UMStash("long-name", "", "", "", "")
+    um2nc.rename_cube_long_names(x_wind_cube, um_var)
+
+
+def test_rename_cubes_long_name_over_limit(x_wind_cube, um_var_empty_std):
+    max_len = 110  # TODO: use constant
+    x_wind_cube.long_name = "0123456789" * 15  # break the 110 char limit
+    x_wind_cube.standard_name = ""
+    assert len(x_wind_cube.long_name) > max_len
+    um2nc.rename_cube_long_names(x_wind_cube, um_var_empty_std)
+    assert len(x_wind_cube.long_name) == max_len
+
+
+

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -257,8 +257,10 @@ def min_cell_method():
 def test_rename_cube_var_name_simple(x_wind_cube, empty_um_var):
     # NB: ignores cell methods functionality
     assert x_wind_cube.var_name == "var_name"  # dummy initial value
-    um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
-    assert x_wind_cube.var_name == "fld_s00i002"
+
+    for um_var in (None, empty_um_var):
+        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        assert x_wind_cube.var_name == "fld_s00i002", f"Failed with um_var={um_var}"
 
 
 def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
@@ -266,8 +268,9 @@ def test_rename_cube_var_rename_with_cell_methods_max(x_wind_cube,
                                                       max_cell_method):
     x_wind_cube.cell_methods = [max_cell_method]
 
-    um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
-    assert x_wind_cube.var_name == "fld_s00i002_max"
+    for um_var in (None, empty_um_var):
+        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        assert x_wind_cube.var_name == "fld_s00i002_max"
 
 
 def test_rename_cube_var_rename_with_cell_methods_min(x_wind_cube,
@@ -275,8 +278,9 @@ def test_rename_cube_var_rename_with_cell_methods_min(x_wind_cube,
                                                       min_cell_method):
     x_wind_cube.cell_methods = [min_cell_method]
 
-    um2nc.rename_cube_var_name(x_wind_cube, None, simple=True)
-    assert x_wind_cube.var_name == "fld_s00i002_min"
+    for um_var in (None, empty_um_var):
+        um2nc.rename_cube_var_name(x_wind_cube, um_var, simple=True)
+        assert x_wind_cube.var_name == "fld_s00i002_min"
 
 
 def test_rename_cube_var_name_unique(x_wind_cube):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -97,6 +97,8 @@ class PartialCube:
     # work around mocks & DummyCube having item_code attr
     var_name: str
     attributes: dict
+    standard_name: str = None
+    long_name: str = None
 
 
 def test_set_item_codes():
@@ -217,3 +219,32 @@ def test_cube_filtering_no_include_exclude(ua_plev_cube, heaviside_uv_cube):
     cubes = [ua_plev_cube, heaviside_uv_cube]
     result = list(um2nc.filtered_cubes(cubes))
     assert result == cubes
+
+
+# cube variable renaming tests
+@pytest.fixture
+def um_var_empty_std():
+    "Return a um_var lookup with an emptry string standard name."
+    um_var = mock.Mock()
+    um_var.standard_name = ""
+    return um_var
+
+
+def test_rename_cube_standard_name_x_wind(um_var_empty_std):
+    fake_cube = PartialCube("var_name", {'STASH': DummyStash(0, 2)}, "x_wind")
+    fake_cube.cell_methods = []
+
+    um2nc.rename_cube_vars(fake_cube, um_var_empty_std,
+                           simple=True, verbose=False)
+
+    assert fake_cube.standard_name == "eastward_wind"
+
+
+def test_rename_cube_standard_name_y_wind(um_var_empty_std):
+    fake_cube = PartialCube("var_name", {'STASH': DummyStash(0, 2)}, "y_wind")
+    fake_cube.cell_methods = []
+
+    um2nc.rename_cube_vars(fake_cube, um_var_empty_std,
+                           simple=True, verbose=False)
+
+    assert fake_cube.standard_name == "northward_wind"

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -602,21 +602,31 @@ def add_global_history(infile, iris_out):
     warnings.warn("um2nc version number not specified!")
 
 
-def rename_cube_var_name(c, um_var, simple: bool):
-    stash_code = c.attributes[STASH]
+# TODO: refactor func sig to take exclusive simple OR unique name field?
+def rename_cube_var_name(cube, um_var, simple: bool):
+    """
+    Modify cube `var_name` to change naming in NetCDF output.
+
+    Parameters
+    ----------
+    cube : iris cube to modify (changes the name in place)
+    um_var : the UM Stash code structure
+    simple : True to replace var_name with "fld_s00i000" style name
+    """
+    stash_code = cube.attributes[STASH]
 
     if simple:
         # TODO: update formatting with fstrings
-        c.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
+        cube.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
     elif um_var.uniquename:
-        c.var_name = um_var.uniquename
+        cube.var_name = um_var.uniquename
 
     # Could there be cases with both max and min?
-    if c.var_name:
-        if any([m.method == 'maximum' for m in c.cell_methods]):
-            c.var_name += "_max"
-        if any([m.method == 'minimum' for m in c.cell_methods]):
-            c.var_name += "_min"
+    if cube.var_name:
+        if any([m.method == 'maximum' for m in cube.cell_methods]):
+            cube.var_name += "_max"
+        if any([m.method == 'minimum' for m in cube.cell_methods]):
+            cube.var_name += "_min"
 
 
 def rename_cube_standard_names(cube, um_var, verbose: bool):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -664,10 +664,17 @@ def rename_cube_standard_names(cube, um_var, verbose: bool):
 
 
 def rename_cube_long_names(cube, um_var):
+    """
+    Modify cube `long_name` attr to change naming for NetCDF output.
+
+    Parameters
+    ----------
+    cube : iris cube to modify (changes the name in place)
+    um_var : the UM Stash code structure
+    """
     # Temporary work around for xconv
-    if cube.long_name:
-        if len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
-            cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
+    if cube.long_name and len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
+        cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
     elif um_var.long_name:
         cube.long_name = um_var.long_name
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -632,12 +632,12 @@ def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
 
     if c.standard_name and umvar.standard_name:
         if c.standard_name != umvar.standard_name:
+            # TODO: remove verbose arg & always warn?
             if verbose:
-                sys.stderr.write("Standard name mismatch %d %d %s %s\n" %
-                                 (stash_code.section,
-                                  stash_code.item,
-                                  c.standard_name,
-                                  umvar.standard_name))
+                msg = (f"Standard name mismatch section={stash_code.section}"
+                       f" item={stash_code.item} standard_name={c.standard_name}"
+                       f" UM var name={umvar.standard_name}")
+                warnings.warn(msg)
 
             c.standard_name = umvar.standard_name
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -342,10 +342,11 @@ def process(infile, outfile, args):
 
         for c in filtered_cubes(cubes, args.include_list, args.exclude_list):
             stashcode = c.attributes['STASH']
-            umvar = stashvar.StashVar(c.item_code)
+            umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
 
             rename_cube_var_name(c, umvar, args.simple)
-            rename_cube_names(c, umvar, args.verbose)
+            rename_cube_standard_names(c, umvar, args.verbose)
+            rename_cube_long_names(c, umvar)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -618,36 +619,38 @@ def rename_cube_var_name(c, um_var, simple: bool):
             c.var_name += "_min"
 
 
-def rename_cube_names(c, umvar, verbose: bool):
-    stash_code = c.attributes[STASH]
+def rename_cube_standard_names(cube, um_var, verbose: bool):
+    stash_code = cube.attributes[STASH]
 
     # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
-    if c.standard_name:
-        if c.standard_name == 'x_wind':
-            c.standard_name = 'eastward_wind'
-        if c.standard_name == 'y_wind':
-            c.standard_name = 'northward_wind'
+    if cube.standard_name:
+        if cube.standard_name == 'x_wind':
+            cube.standard_name = 'eastward_wind'
+        if cube.standard_name == 'y_wind':
+            cube.standard_name = 'northward_wind'
 
-        if c.standard_name and umvar.standard_name:
-            if c.standard_name != umvar.standard_name:
+        if cube.standard_name and um_var.standard_name:
+            if cube.standard_name != um_var.standard_name:
                 # TODO: remove verbose arg & always warn?
                 if verbose:
                     msg = (f"Standard name mismatch section={stash_code.section}"
-                           f" item={stash_code.item} standard_name={c.standard_name}"
-                           f" UM var name={umvar.standard_name}")
+                           f" item={stash_code.item} standard_name={cube.standard_name}"
+                           f" UM var name={um_var.standard_name}")
                     warnings.warn(msg)
 
-                c.standard_name = umvar.standard_name
-    elif umvar.standard_name:
+                cube.standard_name = um_var.standard_name
+    elif um_var.standard_name:
         # If there's no standard_name or long_name from iris, use one from STASH
-        c.standard_name = umvar.standard_name
+        cube.standard_name = um_var.standard_name
 
+
+def rename_cube_long_names(cube, um_var):
     # Temporary work around for xconv
-    if c.long_name:
-        if len(c.long_name) > XCONV_LONG_NAME_LIMIT:
-            c.long_name = c.long_name[:XCONV_LONG_NAME_LIMIT]
-    elif umvar.long_name:
-        c.long_name = umvar.long_name
+    if cube.long_name:
+        if len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
+            cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
+    elif um_var.long_name:
+        cube.long_name = um_var.long_name
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -37,6 +37,9 @@ ITEM_CODE = "item_code"
 GRID_END_GAME = 'EG'
 GRID_NEW_DYNAMICS = 'ND'
 
+# TODO: what is this limit & does it still exist?
+XCONV_LONG_NAME_LIMIT = 110
+
 
 class PostProcessingError(Exception):
     """Generic class for um2nc specific errors."""
@@ -639,11 +642,10 @@ def rename_cube_names(c, umvar, verbose: bool):
         # If there's no standard_name or long_name from iris, use one from STASH
         c.standard_name = umvar.standard_name
 
-    # TODO: what is 110?
     # Temporary work around for xconv
     if c.long_name:
-        if len(c.long_name) > 110:
-            c.long_name = c.long_name[:110]
+        if len(c.long_name) > XCONV_LONG_NAME_LIMIT:
+            c.long_name = c.long_name[:XCONV_LONG_NAME_LIMIT]
     elif umvar.long_name:
         c.long_name = umvar.long_name
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -132,6 +132,7 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
 
 
 # TODO: refactor to "rename level coord"
+# TODO: move this to func renaming section?
 def fix_level_coord(cube, z_rho, z_theta):
     # Rename model_level_number coordinates to better distinguish rho and theta levels
     try:
@@ -352,19 +353,6 @@ def process(infile, outfile, args):
                         sys.stderr.write("Units mismatch %d %d %s %s\n" %
                                          (stashcode.section, stashcode.item, c.units, umvar.units))
                     c.units = umvar.units
-
-            # Temporary work around for xconv
-            if c.long_name and len(c.long_name) > 110:
-                c.long_name = c.long_name[:110]
-
-            # If there's no standard_name or long_name from iris, use one from STASH
-            if not c.standard_name:
-                if umvar.standard_name:
-                    c.standard_name = umvar.standard_name
-
-            if not c.long_name:
-                if umvar.long_name:
-                    c.long_name = umvar.long_name
 
             # Interval in cell methods isn't reliable so better to remove it.
             c.cell_methods = fix_cell_methods(c.cell_methods)
@@ -613,6 +601,7 @@ def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
     stash_code = c.attributes[STASH]
 
     if simple:
+        # TODO: update formatting with fstrings
         c.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
     elif umvar.uniquename:
         c.var_name = umvar.uniquename
@@ -640,6 +629,20 @@ def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
                 warnings.warn(msg)
 
             c.standard_name = umvar.standard_name
+
+    # TODO: what is 110?
+    # Temporary work around for xconv
+    if c.long_name and len(c.long_name) > 110:
+        c.long_name = c.long_name[:110]
+
+    # If there's no standard_name or long_name from iris, use one from STASH
+    if not c.standard_name:
+        if umvar.standard_name:
+            c.standard_name = umvar.standard_name
+
+    if not c.long_name:
+        if umvar.long_name:
+            c.long_name = umvar.long_name
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -675,6 +675,7 @@ def rename_cube_long_name(cube, um_var):
         if len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
             cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
     elif um_var.long_name:
+        # If there's no long_name from iris, use one from STASH
         cube.long_name = um_var.long_name
 
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -641,12 +641,11 @@ def rename_cube_names(c, umvar, verbose: bool):
 
     # TODO: what is 110?
     # Temporary work around for xconv
-    if c.long_name and len(c.long_name) > 110:
-        c.long_name = c.long_name[:110]
-
-    if not c.long_name:
-        if umvar.long_name:
-            c.long_name = umvar.long_name
+    if c.long_name:
+        if len(c.long_name) > 110:
+            c.long_name = c.long_name[:110]
+    elif umvar.long_name:
+        c.long_name = umvar.long_name
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -605,7 +605,7 @@ def add_global_history(infile, iris_out):
 # TODO: refactor func sig to take exclusive simple OR unique name field?
 def rename_cube_var_name(cube, um_var, simple: bool):
     """
-    Modify cube `var_name` to change naming in NetCDF output.
+    Modify cube `var_name` attr to change naming for NetCDF output.
 
     Parameters
     ----------
@@ -630,6 +630,15 @@ def rename_cube_var_name(cube, um_var, simple: bool):
 
 
 def rename_cube_standard_names(cube, um_var, verbose: bool):
+    """
+    Modify cube `standard_name` attr to change naming for NetCDF output.
+
+    Parameters
+    ----------
+    cube : iris cube to modify (changes the name in place)
+    um_var : the UM Stash code structure
+    verbose : True to turn warnings on
+    """
     stash_code = cube.attributes[STASH]
 
     # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
@@ -641,7 +650,7 @@ def rename_cube_standard_names(cube, um_var, verbose: bool):
 
         if cube.standard_name and um_var.standard_name:
             if cube.standard_name != um_var.standard_name:
-                # TODO: remove verbose arg & always warn?
+                # TODO: remove verbose arg & always warn? Control warning visibility at cmd line?
                 if verbose:
                     msg = (f"Standard name mismatch section={stash_code.section}"
                            f" item={stash_code.item} standard_name={cube.standard_name}"

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -601,14 +601,14 @@ def add_global_history(infile, iris_out):
     warnings.warn("um2nc version number not specified!")
 
 
-def rename_cube_var_name(c, umvar, simple: bool):
+def rename_cube_var_name(c, um_var, simple: bool):
     stash_code = c.attributes[STASH]
 
     if simple:
         # TODO: update formatting with fstrings
         c.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
-    elif umvar.uniquename:
-        c.var_name = umvar.uniquename
+    elif um_var.uniquename:
+        c.var_name = um_var.uniquename
 
     # Could there be cases with both max and min?
     if c.var_name:

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -646,16 +646,15 @@ def rename_cube_standard_name(cube, um_var, verbose: bool):
         if cube.standard_name == 'y_wind':
             cube.standard_name = 'northward_wind'
 
-        if cube.standard_name and um_var.standard_name:
-            if cube.standard_name != um_var.standard_name:
-                # TODO: remove verbose arg & always warn? Control warning visibility at cmd line?
-                if verbose:
-                    msg = (f"Standard name mismatch section={stash_code.section}"
-                           f" item={stash_code.item} standard_name={cube.standard_name}"
-                           f" UM var name={um_var.standard_name}")
-                    warnings.warn(msg)
+        if um_var.standard_name and cube.standard_name != um_var.standard_name:
+            # TODO: remove verbose arg & always warn? Control warning visibility at cmd line?
+            if verbose:
+                msg = (f"Standard name mismatch section={stash_code.section}"
+                       f" item={stash_code.item} standard_name={cube.standard_name}"
+                       f" UM var name={um_var.standard_name}")
+                warnings.warn(msg)
 
-                cube.standard_name = um_var.standard_name
+            cube.standard_name = um_var.standard_name
     elif um_var.standard_name:
         # If there's no standard_name from iris, use one from STASH
         cube.standard_name = um_var.standard_name

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -619,31 +619,30 @@ def rename_cube_names(c, umvar, verbose: bool):
     stash_code = c.attributes[STASH]
 
     # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
-    if c.standard_name == 'x_wind':
-        c.standard_name = 'eastward_wind'
-    if c.standard_name == 'y_wind':
-        c.standard_name = 'northward_wind'
+    if c.standard_name:
+        if c.standard_name == 'x_wind':
+            c.standard_name = 'eastward_wind'
+        if c.standard_name == 'y_wind':
+            c.standard_name = 'northward_wind'
 
-    if c.standard_name and umvar.standard_name:
-        if c.standard_name != umvar.standard_name:
-            # TODO: remove verbose arg & always warn?
-            if verbose:
-                msg = (f"Standard name mismatch section={stash_code.section}"
-                       f" item={stash_code.item} standard_name={c.standard_name}"
-                       f" UM var name={umvar.standard_name}")
-                warnings.warn(msg)
+        if c.standard_name and umvar.standard_name:
+            if c.standard_name != umvar.standard_name:
+                # TODO: remove verbose arg & always warn?
+                if verbose:
+                    msg = (f"Standard name mismatch section={stash_code.section}"
+                           f" item={stash_code.item} standard_name={c.standard_name}"
+                           f" UM var name={umvar.standard_name}")
+                    warnings.warn(msg)
 
-            c.standard_name = umvar.standard_name
+                c.standard_name = umvar.standard_name
+    elif umvar.standard_name:
+        # If there's no standard_name or long_name from iris, use one from STASH
+        c.standard_name = umvar.standard_name
 
     # TODO: what is 110?
     # Temporary work around for xconv
     if c.long_name and len(c.long_name) > 110:
         c.long_name = c.long_name[:110]
-
-    # If there's no standard_name or long_name from iris, use one from STASH
-    if not c.standard_name:
-        if umvar.standard_name:
-            c.standard_name = umvar.standard_name
 
     if not c.long_name:
         if umvar.long_name:

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -613,11 +613,9 @@ def rename_cube_var_name(cube, um_var, simple: bool):
     um_var : the UM Stash code structure
     simple : True to replace var_name with "fld_s00i000" style name
     """
-    stash_code = cube.attributes[STASH]
-
     if simple:
-        # TODO: update formatting with fstrings
-        cube.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
+        stash_code = cube.attributes[STASH]
+        cube.var_name = f"fld_s{stash_code.section:02}i{stash_code.item:03}"
     elif um_var.uniquename:
         cube.var_name = um_var.uniquename
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -345,8 +345,8 @@ def process(infile, outfile, args):
             umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
 
             rename_cube_var_name(c, umvar, args.simple)
-            rename_cube_standard_names(c, umvar, args.verbose)
-            rename_cube_long_names(c, umvar)
+            rename_cube_standard_name(c, umvar, args.verbose)
+            rename_cube_long_name(c, umvar)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -627,7 +627,7 @@ def rename_cube_var_name(cube, um_var, simple: bool):
             cube.var_name += "_min"
 
 
-def rename_cube_standard_names(cube, um_var, verbose: bool):
+def rename_cube_standard_name(cube, um_var, verbose: bool):
     """
     Modify cube `standard_name` attr to change naming for NetCDF output.
 
@@ -661,7 +661,7 @@ def rename_cube_standard_names(cube, um_var, verbose: bool):
         cube.standard_name = um_var.standard_name
 
 
-def rename_cube_long_names(cube, um_var):
+def rename_cube_long_name(cube, um_var):
     """
     Modify cube `long_name` attr to change naming for NetCDF output.
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -340,33 +340,7 @@ def process(infile, outfile, args):
             stashcode = c.attributes['STASH']
             umvar = stashvar.StashVar(c.item_code)
 
-            if args.simple:
-                c.var_name = 'fld_s%2.2di%3.3d' % (stashcode.section, stashcode.item)
-            elif umvar.uniquename:
-                c.var_name = umvar.uniquename
-
-            # Could there be cases with both max and min?
-            if c.var_name:
-                if any([m.method == 'maximum' for m in c.cell_methods]):
-                    c.var_name += "_max"
-                if any([m.method == 'minimum' for m in c.cell_methods]):
-                    c.var_name += "_min"
-
-            # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
-            if c.standard_name == 'x_wind':
-                c.standard_name = 'eastward_wind'
-            if c.standard_name == 'y_wind':
-                c.standard_name = 'northward_wind'
-
-            if c.standard_name and umvar.standard_name:
-                if c.standard_name != umvar.standard_name:
-                    if args.verbose:
-                        sys.stderr.write("Standard name mismatch %d %d %s %s\n" %
-                                         (stashcode.section,
-                                          stashcode.item,
-                                          c.standard_name,
-                                          umvar.standard_name))
-                    c.standard_name = umvar.standard_name
+            rename_cube_vars(c, stashcode, umvar, args.simple, args.verbose)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -633,6 +607,37 @@ def add_global_history(infile, iris_out):
 
     iris_out.update_global_attributes({'history': history})
     warnings.warn("um2nc version number not specified!")
+
+
+def rename_cube_vars(c, stashcode, umvar, simple: bool, verbose: bool):
+    if simple:
+        c.var_name = 'fld_s%2.2di%3.3d' % (stashcode.section, stashcode.item)
+    elif umvar.uniquename:
+        c.var_name = umvar.uniquename
+
+    # Could there be cases with both max and min?
+    if c.var_name:
+        if any([m.method == 'maximum' for m in c.cell_methods]):
+            c.var_name += "_max"
+        if any([m.method == 'minimum' for m in c.cell_methods]):
+            c.var_name += "_min"
+
+    # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
+    if c.standard_name == 'x_wind':
+        c.standard_name = 'eastward_wind'
+    if c.standard_name == 'y_wind':
+        c.standard_name = 'northward_wind'
+
+    if c.standard_name and umvar.standard_name:
+        if c.standard_name != umvar.standard_name:
+            if verbose:
+                sys.stderr.write("Standard name mismatch %d %d %s %s\n" %
+                                 (stashcode.section,
+                                  stashcode.item,
+                                  c.standard_name,
+                                  umvar.standard_name))
+
+            c.standard_name = umvar.standard_name
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -344,9 +344,9 @@ def process(infile, outfile, args):
             stashcode = c.attributes['STASH']
             umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
 
-            fix_var_name(c, umvar, args.simple)
-            fix_standard_name(c, umvar, args.verbose)
-            fix_long_name(c, umvar)
+            fix_var_name(c, umvar.uniquename, args.simple)
+            fix_standard_name(c, umvar.standard_name, args.verbose)
+            fix_long_name(c, umvar.long_name)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -603,21 +603,21 @@ def add_global_history(infile, iris_out):
 
 
 # TODO: refactor func sig to take exclusive simple OR unique name field?
-def fix_var_name(cube, um_var, simple: bool):
+def fix_var_name(cube, um_unique_name, simple: bool):
     """
     Modify cube `var_name` attr to change naming for NetCDF output.
 
     Parameters
     ----------
     cube : iris cube to modify (changes the name in place)
-    um_var : the UM Stash code structure
+    um_unique_name : the UM Stash unique name
     simple : True to replace var_name with "fld_s00i000" style name
     """
     if simple:
         stash_code = cube.attributes[STASH]
         cube.var_name = f"fld_s{stash_code.section:02}i{stash_code.item:03}"
-    elif um_var.uniquename:
-        cube.var_name = um_var.uniquename
+    elif um_unique_name:
+        cube.var_name = um_unique_name
 
     # Could there be cases with both max and min?
     if cube.var_name:
@@ -627,14 +627,14 @@ def fix_var_name(cube, um_var, simple: bool):
             cube.var_name += "_min"
 
 
-def fix_standard_name(cube, um_var, verbose: bool):
+def fix_standard_name(cube, um_standard_name, verbose: bool):
     """
     Modify cube `standard_name` attr to change naming for NetCDF output.
 
     Parameters
     ----------
     cube : iris cube to modify (changes the name in place)
-    um_var : the UM Stash code structure
+    um_standard_name : the UM Stash standard name
     verbose : True to turn warnings on
     """
     stash_code = cube.attributes[STASH]
@@ -646,36 +646,37 @@ def fix_standard_name(cube, um_var, verbose: bool):
         if cube.standard_name == 'y_wind':
             cube.standard_name = 'northward_wind'
 
-        if um_var.standard_name and cube.standard_name != um_var.standard_name:
+        if um_standard_name and cube.standard_name != um_standard_name:
             # TODO: remove verbose arg & always warn? Control warning visibility at cmd line?
             if verbose:
+                # TODO: show combined stash code instead?
                 msg = (f"Standard name mismatch section={stash_code.section}"
                        f" item={stash_code.item} standard_name={cube.standard_name}"
-                       f" UM var name={um_var.standard_name}")
+                       f" UM var name={um_standard_name}")
                 warnings.warn(msg)
 
-            cube.standard_name = um_var.standard_name
-    elif um_var.standard_name:
+            cube.standard_name = um_standard_name
+    elif um_standard_name:
         # If there's no standard_name from iris, use one from STASH
-        cube.standard_name = um_var.standard_name
+        cube.standard_name = um_standard_name
 
 
-def fix_long_name(cube, um_var):
+def fix_long_name(cube, um_long_name):
     """
     Modify cube `long_name` attr to change naming for NetCDF output.
 
     Parameters
     ----------
     cube : iris cube to modify (changes the name in place)
-    um_var : the UM Stash code structure
+    um_long_name : the UM Stash long name
     """
     # Temporary work around for xconv
     if cube.long_name:
         if len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
             cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
-    elif um_var.long_name:
+    elif um_long_name:
         # If there's no long_name from iris, use one from STASH
-        cube.long_name = um_var.long_name
+        cube.long_name = um_long_name
 
 
 if __name__ == '__main__':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -344,9 +344,9 @@ def process(infile, outfile, args):
             stashcode = c.attributes['STASH']
             umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
 
-            rename_cube_var_name(c, umvar, args.simple)
-            rename_cube_standard_name(c, umvar, args.verbose)
-            rename_cube_long_name(c, umvar)
+            fix_var_name(c, umvar, args.simple)
+            fix_standard_name(c, umvar, args.verbose)
+            fix_long_name(c, umvar)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -603,7 +603,7 @@ def add_global_history(infile, iris_out):
 
 
 # TODO: refactor func sig to take exclusive simple OR unique name field?
-def rename_cube_var_name(cube, um_var, simple: bool):
+def fix_var_name(cube, um_var, simple: bool):
     """
     Modify cube `var_name` attr to change naming for NetCDF output.
 
@@ -627,7 +627,7 @@ def rename_cube_var_name(cube, um_var, simple: bool):
             cube.var_name += "_min"
 
 
-def rename_cube_standard_name(cube, um_var, verbose: bool):
+def fix_standard_name(cube, um_var, verbose: bool):
     """
     Modify cube `standard_name` attr to change naming for NetCDF output.
 
@@ -660,7 +660,7 @@ def rename_cube_standard_name(cube, um_var, verbose: bool):
         cube.standard_name = um_var.standard_name
 
 
-def rename_cube_long_name(cube, um_var):
+def fix_long_name(cube, um_var):
     """
     Modify cube `long_name` attr to change naming for NetCDF output.
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -657,7 +657,7 @@ def rename_cube_standard_name(cube, um_var, verbose: bool):
 
                 cube.standard_name = um_var.standard_name
     elif um_var.standard_name:
-        # If there's no standard_name or long_name from iris, use one from STASH
+        # If there's no standard_name from iris, use one from STASH
         cube.standard_name = um_var.standard_name
 
 
@@ -671,8 +671,9 @@ def rename_cube_long_name(cube, um_var):
     um_var : the UM Stash code structure
     """
     # Temporary work around for xconv
-    if cube.long_name and len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
-        cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
+    if cube.long_name:
+        if len(cube.long_name) > XCONV_LONG_NAME_LIMIT:
+            cube.long_name = cube.long_name[:XCONV_LONG_NAME_LIMIT]
     elif um_var.long_name:
         cube.long_name = um_var.long_name
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -340,7 +340,7 @@ def process(infile, outfile, args):
             stashcode = c.attributes['STASH']
             umvar = stashvar.StashVar(c.item_code)
 
-            rename_cube_vars(c, stashcode, umvar, args.simple, args.verbose)
+            rename_cube_vars(c, umvar, args.simple, args.verbose)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -609,9 +609,11 @@ def add_global_history(infile, iris_out):
     warnings.warn("um2nc version number not specified!")
 
 
-def rename_cube_vars(c, stashcode, umvar, simple: bool, verbose: bool):
+def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
+    stash_code = c.attributes[STASH]
+
     if simple:
-        c.var_name = 'fld_s%2.2di%3.3d' % (stashcode.section, stashcode.item)
+        c.var_name = 'fld_s%2.2di%3.3d' % (stash_code.section, stash_code.item)
     elif umvar.uniquename:
         c.var_name = umvar.uniquename
 
@@ -632,8 +634,8 @@ def rename_cube_vars(c, stashcode, umvar, simple: bool, verbose: bool):
         if c.standard_name != umvar.standard_name:
             if verbose:
                 sys.stderr.write("Standard name mismatch %d %d %s %s\n" %
-                                 (stashcode.section,
-                                  stashcode.item,
+                                 (stash_code.section,
+                                  stash_code.item,
                                   c.standard_name,
                                   umvar.standard_name))
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -341,7 +341,8 @@ def process(infile, outfile, args):
             stashcode = c.attributes['STASH']
             umvar = stashvar.StashVar(c.item_code)
 
-            rename_cube_vars(c, umvar, args.simple, args.verbose)
+            rename_cube_var_name(c, umvar, args.simple)
+            rename_cube_names(c, umvar, args.verbose)
 
             if c.units and umvar.units:
                 # Simple testing c.units == umvar.units doesn't
@@ -597,7 +598,7 @@ def add_global_history(infile, iris_out):
     warnings.warn("um2nc version number not specified!")
 
 
-def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
+def rename_cube_var_name(c, umvar, simple: bool):
     stash_code = c.attributes[STASH]
 
     if simple:
@@ -612,6 +613,10 @@ def rename_cube_vars(c, umvar, simple: bool, verbose: bool):
             c.var_name += "_max"
         if any([m.method == 'minimum' for m in c.cell_methods]):
             c.var_name += "_min"
+
+
+def rename_cube_names(c, umvar, verbose: bool):
+    stash_code = c.attributes[STASH]
 
     # The iris name mapping seems wrong for these - perhaps assuming rotated grids?
     if c.standard_name == 'x_wind':


### PR DESCRIPTION
Closes #51. Also related to #14.

Several elements are included in this PR (which is larger than I'd prefer):
* Extracting cube renaming code to funcs
* Adding multiple test fixtures and unit tests
* Reordering some naming logic (this didn't break testing on my device)

Overall, this moves ~37 lines of code out from `process()`.

Gaps:
* `process()` still lacks a test, but is now only ~1 page of code
* Some mocks may not represent real object config, but I've tweaked variables to skip code segments & force specific code segments to execute
* A few code branches aren't covered by the tests, usually where there's a normal return from nothing happening

For the review, any opinions on the restructure, gaps & correctness checks are welcome!