### PR TITLE
Refactor process() testing & cleaning cube masking/filtering logic

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -158,7 +158,7 @@ def test_process_no_heaviside_drop_cubes(air_temp_cube, precipitation_flux_cube,
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube]
 
         m_iris_load.return_value = cubes
-        m_saver().__enter__.return_value = mock.Mock("mock_sman")
+        m_saver().__enter__ = mock.Mock(name="mock_sman")
         std_args.verbose = True  # test some warning branches
 
         # air temp & geo potential should be dropped in process()
@@ -183,7 +183,7 @@ def test_process_all_cubes_filtered(air_temp_cube, geo_potential_cube,
     ):
         m_mule_vars.return_value = mule_vars
         m_iris_load.return_value = [air_temp_cube, geo_potential_cube]
-        m_saver().__enter__.return_value = mock.Mock("mock_sman")
+        m_saver().__enter__ = mock.Mock(name="mock_sman")
 
         # all cubes should be dropped
         assert um2nc.process(fake_in_path, fake_out_path, std_args) == []
@@ -220,7 +220,7 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
             c.cell_methods = []
 
         m_iris_load.return_value = cubes
-        m_saver().__enter__.return_value = mock.Mock("mock_sman")
+        m_saver().__enter__ = mock.Mock(name="mock_sman")
 
         # all cubes should be processed & not dropped
         processed = um2nc.process(fake_in_path, fake_out_path, std_args)
@@ -248,7 +248,7 @@ def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cub
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube]
 
         m_iris_load.return_value = cubes
-        m_saver().__enter__.return_value = mock.Mock("mock_sman")
+        m_saver().__enter__ = mock.Mock(name="mock_sman")
         std_args.nomask = True
 
         # all cubes should be kept with masking off

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -140,7 +140,7 @@ def test_process_without_masking(air_temp_cube, precipitation_flux_cube, mule_va
         um2nc.process(fake_in_path, fake_out_path, std_args)
 
         assert m_sman.update_global_attributes.called
-        assert m_saver.write.called is False  # write I/O prevented
+        assert m_sman.write.called is False  # write I/O prevented
         assert m_coord.called
         assert m_level.called
         assert m_apply_mask.called is False
@@ -169,7 +169,7 @@ def test_process_all_cubes_filtered(air_temp_cube, mule_vars, std_args,
         um2nc.process(fake_in_path, fake_out_path, std_args)
 
         assert m_sman.update_global_attributes.called is False
-        assert m_saver.write.called is False  # write I/O prevented
+        assert m_sman.write.called is False  # write I/O prevented
 
 
 def test_process_masking(air_temp_cube, precipitation_flux_cube,
@@ -210,7 +210,7 @@ def test_process_masking(air_temp_cube, precipitation_flux_cube,
 
         assert m_sman.update_global_attributes.called
         assert m_sman.update_global_attributes.call_count == 2
-        assert m_saver.write.called is False  # write I/O prevented
+        assert m_sman.write.called is False  # write I/O prevented
         assert m_coord.called
         assert m_level.called
         assert m_apply_mask.called

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -79,7 +79,7 @@ def test_stash_code_to_item_code_conversion():
     assert result == 30255
 
 
-@dataclass
+@dataclass(frozen=True)
 class DummyStash:
     """
     Partial Stash representation for testing.

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -158,8 +158,7 @@ def test_process_no_heaviside_drop_cubes(air_temp_cube, precipitation_flux_cube,
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube]
 
         m_iris_load.return_value = cubes
-        m_sman = mock.Mock()  # mock `sman` var to prevent I/O
-        m_saver().__enter__.return_value = m_sman
+        m_saver().__enter__.return_value = mock.Mock("mock_sman")
         std_args.verbose = True  # test some warning branches
 
         # air temp & geo potential should be dropped in process()
@@ -184,8 +183,7 @@ def test_process_all_cubes_filtered(air_temp_cube, geo_potential_cube,
     ):
         m_mule_vars.return_value = mule_vars
         m_iris_load.return_value = [air_temp_cube, geo_potential_cube]
-        m_sman = mock.Mock()
-        m_saver().__enter__.return_value = m_sman
+        m_saver().__enter__.return_value = mock.Mock("mock_sman")
 
         # all cubes should be dropped
         assert um2nc.process(fake_in_path, fake_out_path, std_args) == []
@@ -222,8 +220,7 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
             c.cell_methods = []
 
         m_iris_load.return_value = cubes
-        m_sman = mock.Mock()
-        m_saver().__enter__.return_value = m_sman
+        m_saver().__enter__.return_value = mock.Mock("mock_sman")
 
         # all cubes should be processed & not dropped
         processed = um2nc.process(fake_in_path, fake_out_path, std_args)
@@ -251,8 +248,7 @@ def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cub
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube]
 
         m_iris_load.return_value = cubes
-        m_sman = mock.Mock()
-        m_saver().__enter__.return_value = m_sman
+        m_saver().__enter__.return_value = mock.Mock("mock_sman")
         std_args.nomask = True
 
         # all cubes should be kept with masking off

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -71,7 +71,7 @@ def set_default_attrs(cube, item_code: int, var_name: str):
                           "data": None,
                           })
 
-    section, item = split_item_code(item_code)
+    section, item = um2nc.to_stash_code(item_code)
     cube.attributes = {um2nc.STASH: DummyStash(section, item)}
 
 
@@ -215,7 +215,7 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
         # TODO: convert heaviside cubes to NonCallableMagicMock like other fixtures?
         for c in [heaviside_uv_cube, heaviside_t_cube]:
             # add attrs to mimic real cubes
-            attrs = {um2nc.STASH: DummyStash(*split_item_code(c.item_code))}
+            attrs = {um2nc.STASH: DummyStash(*um2nc.to_stash_code(c.item_code))}
             c.attributes = attrs
             c.cell_methods = []
 
@@ -262,9 +262,9 @@ def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cub
             assert pc in cubes
 
 
-def split_item_code(item_code: int):
-    """Helper func: convert item code back to older section & item components."""
-    return item_code // 1000, item_code % 1000
+def test_to_stash_code():
+    assert um2nc.to_stash_code(5126) == (5, 126)
+    assert um2nc.to_stash_code(30204) == (30, 204)
 
 
 def test_get_eg_grid_type():

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -212,7 +212,7 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube,
                  heaviside_uv_cube, heaviside_t_cube]
 
-        # TODO: convert heaviside cubes to NonCallableMagicMock as per other fixtures?
+        # TODO: convert heaviside cubes to NonCallableMagicMock like other fixtures?
         for c in [heaviside_uv_cube, heaviside_t_cube]:
             # add attrs to mimic real cubes
             attrs = {um2nc.STASH: DummyStash(*split_item_code(c.item_code))}
@@ -225,6 +225,9 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
         # all cubes should be processed & not dropped
         processed = um2nc.process(fake_in_path, fake_out_path, std_args)
         assert len(processed) == len(cubes)
+
+        for pc in processed:
+            assert pc in cubes
 
 
 def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cube,
@@ -254,6 +257,9 @@ def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cub
         # all cubes should be kept with masking off
         processed = um2nc.process(fake_in_path, fake_out_path, std_args)
         assert len(processed) == len(cubes)
+
+        for pc in processed:
+            assert pc in cubes
 
 
 def split_item_code(item_code: int):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -161,19 +161,25 @@ def test_process_no_heaviside_drop_cubes(air_temp_cube, precipitation_flux_cube,
         m_saver().__enter__ = mock.Mock(name="mock_sman")
         std_args.verbose = True  # test some warning branches
 
+        # trying to mask None will break in numpy
+        assert precipitation_flux_cube.data is None
+
         # air temp & geo potential should be dropped in process()
         processed = um2nc.process(fake_in_path, fake_out_path, std_args)
         assert len(processed) == 1
         cube = processed[0]
 
         assert cube is precipitation_flux_cube
-        assert cube.data is None  # masking wasn't applied
+
+        # contrived testing: if the masking code was reached for some reason,
+        # the test would fail during process()
+        assert cube.data is None  # masking wasn't called/nothing changed
 
 
 def test_process_all_cubes_filtered(air_temp_cube, geo_potential_cube,
                                     mule_vars, std_args,
                                     fake_in_path, fake_out_path):
-    """Ensure process() exists early if all cubes are removed in filtering."""
+    """Ensure process() exits early if all cubes are removed in filtering."""
     with (
         mock.patch("mule.load_umfile"),
         mock.patch("umpost.um2netcdf.process_mule_vars") as m_mule_vars,

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -102,8 +102,9 @@ def test_process_without_masking(air_temp_cube, precipitation_flux_cube, mule_va
     """Attempts end-to-end test of process(), ignoring cubes requiring masking."""
 
     # FIXME: this convoluted setup is a big code stench
-    #        use this to gradually refactor process()
-    #        add naming vars to the dummy cubes
+    #        use these tests to gradually refactor process()
+    # TODO: move towards a design where input & output I/O is extracted from process()
+    #       process()'s core should operate with *data only* args
     with mock.patch("mule.load_umfile"):  # ignore m_load_umfile as process_mule_vars is mocked
         with mock.patch("umpost.um2netcdf.process_mule_vars") as m_mule_vars:
             m_mule_vars.return_value = mule_vars

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -129,10 +129,14 @@ class DummyCube:
         self.units = None or units
 
 
-def test_set_item_codes_fail_on_overwrite():
-    cubes = [DummyCube(1007, "fake_var")]
-    with pytest.raises(NotImplementedError):
-        um2nc.set_item_codes(cubes)
+def test_set_item_codes_avoid_overwrite():
+    item_code = 1007
+    item_code2 = 51006
+
+    cubes = [DummyCube(item_code, "fake_var"), DummyCube(item_code2, "fake_var2")]
+    um2nc.set_item_codes(cubes)
+    assert cubes[0].item_code == item_code
+    assert cubes[1].item_code == item_code2
 
 
 @pytest.fixture

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -168,23 +168,18 @@ def test_process_all_cubes_filtered(air_temp_cube, mule_vars, std_args,
                                     fake_in_path, fake_out_path):
     """Ensure process() exists early if all cubes are removed in filtering."""
     with (
-        mock.patch("mule.load_umfile"),  # ignore m_load_umfile as process_mule_vars is mocked
+        mock.patch("mule.load_umfile"),
         mock.patch("umpost.um2netcdf.process_mule_vars") as m_mule_vars,
+
         mock.patch("iris.load") as m_iris_load,
-        mock.patch("iris.fileformats.netcdf.Saver") as m_saver, # prevent I/O
+        mock.patch("iris.fileformats.netcdf.Saver") as m_saver,  # prevent I/O
     ):
         m_mule_vars.return_value = mule_vars
-        section, item = split_item_code(air_temp_cube.item_code)
-        air_temp_cube.attributes = {um2nc.STASH: DummyStash(section, item)}
         m_iris_load.return_value = [air_temp_cube]
-
         m_sman = mock.Mock()
         m_saver().__enter__.return_value = m_sman
 
-        um2nc.process(fake_in_path, fake_out_path, std_args)
-
-        assert m_sman.update_global_attributes.called is False
-        assert m_sman.write.called is False  # write I/O prevented
+        assert um2nc.process(fake_in_path, fake_out_path, std_args) == []
 
 
 def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -490,6 +490,11 @@ def to_item_code(stash_code):
     return 1000 * stash_code.section + stash_code.item
 
 
+def to_stash_code(item_code: int):
+    """Helper: convert item code back to older section & item components."""
+    return item_code // 1000, item_code % 1000
+
+
 def set_item_codes(cubes):
     for cube in cubes:
         if hasattr(cube, ITEM_CODE):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -355,17 +355,11 @@ def process(infile, outfile, args):
 
             if do_mask:
                 # Pressure level data should be masked
-                if require_heaviside_uv(c.item_code):
-                    if heaviside_uv:
-                        apply_mask(c, heaviside_uv, args.hcrit)
-                    else:
-                        continue
+                if require_heaviside_uv(c.item_code) and heaviside_uv:
+                    apply_mask(c, heaviside_uv, args.hcrit)
 
-                if require_heaviside_t(c.item_code):
-                    if heaviside_t:
-                        apply_mask(c, heaviside_t, args.hcrit)
-                    else:
-                        continue
+                if require_heaviside_t(c.item_code) and heaviside_t:
+                    apply_mask(c, heaviside_t, args.hcrit)
 
             if args.verbose:
                 print(c.name(), c.item_code)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -40,8 +40,12 @@ GRID_NEW_DYNAMICS = 'ND'
 # TODO: what is this limit & does it still exist?
 XCONV_LONG_NAME_LIMIT = 110
 
-NC_FORMATS = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
-              3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
+NC_FORMATS = {
+    1: 'NETCDF3_CLASSIC',
+    2: 'NETCDF3_64BIT',
+    3: 'NETCDF4',
+    4: 'NETCDF4_CLASSIC'
+}
 
 
 class PostProcessingError(Exception):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -465,8 +465,9 @@ def to_item_code(stash_code):
 def set_item_codes(cubes):
     for cube in cubes:
         if hasattr(cube, ITEM_CODE):
-            msg = f"Cube {cube.var_name} already has 'item_code' attribute"
-            raise NotImplementedError(msg)
+            msg = f"Cube {cube.var_name} already has 'item_code' attribute, skipping."
+            warnings.warn(msg)
+            continue
 
         # hack: manually store item_code in cubes
         item_code = to_item_code(cube.attributes[STASH])

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -40,6 +40,9 @@ GRID_NEW_DYNAMICS = 'ND'
 # TODO: what is this limit & does it still exist?
 XCONV_LONG_NAME_LIMIT = 110
 
+NC_FORMATS = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
+              3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
+
 
 class PostProcessingError(Exception):
     """Generic class for um2nc specific errors."""
@@ -317,12 +320,7 @@ def process(infile, outfile, args):
         check_pressure_warnings(need_heaviside_uv, heaviside_uv,
                                 need_heaviside_t, heaviside_t)
 
-    # TODO: can NC type be a single arg?
-    #       defer to new process() API
-    nc_formats = {1: 'NETCDF3_CLASSIC', 2: 'NETCDF3_64BIT',
-                  3: 'NETCDF4', 4: 'NETCDF4_CLASSIC'}
-
-    with iris.fileformats.netcdf.Saver(outfile, nc_formats[args.nckind]) as sman:
+    with iris.fileformats.netcdf.Saver(outfile, NC_FORMATS[args.nckind]) as sman:
         # TODO: move attribute mods to end of process() to group sman ops
         #       do when sman ops refactored into a write function
         # Add global attributes

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -314,7 +314,9 @@ def process(infile, outfile, args):
     cubes = iris.load(infile)
     set_item_codes(cubes)
     cubes.sort(key=lambda cs: cs.item_code)
-    cubes = [c for c in filtered_cubes(cubes, args.include_list, args.exclude_list)]
+
+    if args.include_list or args.exclude_list:
+        cubes = [c for c in filtered_cubes(cubes, args.include_list, args.exclude_list)]
 
     do_masking = not args.nomask
     heaviside_uv, heaviside_t = get_pressure_levels(cubes)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -164,6 +164,7 @@ def fix_level_coord(cube, z_rho, z_theta):
                 c_sigma.var_name = 'sigma_theta'
 
 
+# TODO: split cube ops into functions, this will likely increase process() workflow steps
 def cubewrite(cube, sman, compression, use64bit, verbose):
     try:
         plevs = cube.coord('pressure')
@@ -366,6 +367,8 @@ def process(infile, outfile, args):
             if args.verbose:
                 print(c.name(), c.item_code)
 
+            # TODO: split cube ops into functions, splitting will increase process() workflow
+            #       unless the steps are pushed out to sub workflow functions
             cubewrite(c, sman, args.compression, args.use64bit, args.verbose)
 
 
@@ -393,7 +396,6 @@ def process_mule_vars(fields_file: mule.ff.FieldsFile):
         msg = "mule 2020.01.1 doesn't handle pathlib Paths properly"
         raise NotImplementedError(msg)  # fail fast
 
-    # TODO: eventually move these calls closer to their usage
     grid_type = get_grid_type(fields_file)
     d_lat, d_lon = get_grid_spacing(fields_file)
     z_rho, z_theta = get_z_sea_constants(fields_file)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -380,9 +380,10 @@ def process(infile, outfile, args):
 MuleVars = collections.namedtuple("MuleVars", "grid_type, d_lat, d_lon, z_rho, z_theta")
 
 
+# TODO: rename this function, it's *getting* variables
 def process_mule_vars(fields_file: mule.ff.FieldsFile):
     """
-    Extract model levels with mule.
+    Extract model levels and grid structure with Mule.
 
     The model levels help with workflow dimension naming.
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -555,7 +555,11 @@ def is_heaviside_t(item_code):
 
 def non_masking_cubes(cubes, heaviside_uv, heaviside_t, verbose: bool):
     """
-    Yields cubes that do not require pressure level masking.
+    Yields cubes that:
+    * do not require pressure level masking
+    * require pressure level masking & the relevant masking cube exists
+
+    This provides filtering to remove cubes from workflows for efficiency.
 
     Parameters
     ----------

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -328,6 +328,8 @@ def process(infile, outfile, args):
             print("No cubes left to process after filtering")
             return
 
+    cubes = [c for c in filtered_cubes(cubes, args.include_list, args.exclude_list)]
+
     with iris.fileformats.netcdf.Saver(outfile, NC_FORMATS[args.nckind]) as sman:
         # TODO: move attribute mods to end of process() to group sman ops
         #       do when sman ops refactored into a write function
@@ -337,7 +339,7 @@ def process(infile, outfile, args):
 
         sman.update_global_attributes({'Conventions': 'CF-1.6'})
 
-        for c in filtered_cubes(cubes, args.include_list, args.exclude_list):
+        for c in cubes:
             umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
 
             fix_var_name(c, umvar.uniquename, args.simple)
@@ -371,6 +373,8 @@ def process(infile, outfile, args):
             # TODO: split cubewrite ops into funcs & bring those steps into process() workflow
             #       or a sub process workflow function (like process_mule_vars())
             cubewrite(c, sman, args.compression, args.use64bit, args.verbose)
+
+    return cubes
 
 
 MuleVars = collections.namedtuple("MuleVars", "grid_type, d_lat, d_lon, z_rho, z_theta")

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -319,7 +319,7 @@ def process(infile, outfile, args):
         cubes = [c for c in filtered_cubes(cubes, args.include_list, args.exclude_list)]
 
     do_masking = not args.nomask
-    heaviside_uv, heaviside_t = get_pressure_levels(cubes)
+    heaviside_uv, heaviside_t = get_heaviside_cubes(cubes)
 
     if do_masking:
         # drop cubes which cannot be pressure masked if heaviside uv or t is missing
@@ -508,12 +508,19 @@ def set_item_codes(cubes):
         setattr(cube, ITEM_CODE, item_code)
 
 
-def get_pressure_levels(cubes):
+def get_heaviside_cubes(cubes):
     """
-    TODO docs
+    Finds heaviside_uv, heaviside_t cubes in given sequence.
+
+    Parameters
+    ----------
+    cubes : sequence of cubes.
+
+    Returns
+    -------
+    (heaviside_uv, heaviside_t) tuple, or None for either cube where the
+        heaviside_uv/t cubes not found.
     """
-    # Check whether there are any pressure level fields that should be masked. Can use temperature
-    # to mask instantaneous fields, so really should check whether these are time means
     heaviside_uv = None
     heaviside_t = None
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -326,7 +326,7 @@ def process(infile, outfile, args):
 
         if not cubes:
             print("No cubes left to process after filtering")
-            return
+            return []
 
     cubes = [c for c in filtered_cubes(cubes, args.include_list, args.exclude_list)]
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -364,8 +364,8 @@ def process(infile, outfile, args):
             if args.verbose:
                 print(c.name(), c.item_code)
 
-            # TODO: split cube ops into functions, splitting will increase process() workflow
-            #       unless the steps are pushed out to sub workflow functions
+            # TODO: split cubewrite ops into funcs & bring those steps into process() workflow
+            #       or a sub process workflow function (like process_mule_vars())
             cubewrite(c, sman, args.compression, args.use64bit, args.verbose)
 
 


### PR DESCRIPTION
Resolves #50 (also related to #14).

This is a fairly complicated PR around testing & refactoring the central `process()` workflow function in `um2netcdf/um2nc`.

This work is intended to provide initial testing & cleanup of `process()`, providing a framework to ensure the workflow is consistent over future refactoring steps.

**For background:**
* `um2nc` processes UM files, modifying variables & saving to NetCDF files
* The core `um2nc` driver is the `process()` workflow function (it's also the main API entry point)
* Commit 0 in this repo had no unit tests
* `process()` was initially 140 lines of processing logic & too difficult to unit test
* Recent work extracted blocks of functionality (e.g. variable renaming) to separate functions. This simplified & compressed `process()` to focus on the workflow logic
* As `process()` shrank, I identified tricky logic & inefficient data handling (see #50 notes)
* The requirement to retrofit unit testing naturally encourages refactoring to simplify workflow logic

**Known Problems:**
* Two `process()`  tests require _substantial setup_ & multiple ugly ~~nested~~ `mock.patch()` calls. This is partly due to complexity in `process()`, touching separate I/O libraries.
* Both `mule` and `iris` fields file objects are complex
  - Multiple attrs are created _dynamically_ when opened
  - Mocking these is tricky with the `spec=` option, since `spec` only detects init time attributes
* Some mocks may not represent real object config, however I've tweaked some code to skip some side issues
* `process()` doesn't return success or failure data for the cubes

**Future steps/direction/thoughts:**
* For upcoming steps, `process()` is likely to gain cube modification functionality as it is extracted from `cubewrite()`
* `process()` tests should be flexible to expand to cover the additional mod steps
* `process()` needs reordering to divide into 3 broad steps: input I/O, cube modification, output I/O
  - Idea: sub-steps could be refactored to independent sub-workflow funcs, which suggests `process()` tests could be split into smaller chunks. This ought to reduce setup dependencies, reducing test setup burden (e.g. less `mock.patch()` nesting)

For the review, any opinions on the restructure, gaps & correctness checks are welcome! It would be good to reduce the complex setup.