### PR TITLE
Testing/repairing `apply_mask()`

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1,4 +1,7 @@
 import unittest.mock as mock
+
+import math
+import copy
 from dataclasses import dataclass
 from collections import namedtuple
 
@@ -266,6 +269,25 @@ def test_process_no_masking_keep_all_cubes(air_temp_cube, precipitation_flux_cub
 
         for pc in processed:
             assert pc in cubes
+
+
+def test_apply_mask_with_matching_grid_extents(air_temp_cube, heaviside_uv_cube):
+    """TODO"""
+    shape = (2, 5, 3)
+    total = math.prod(shape)
+
+    air_temp_cube.shape = shape
+    orig_temp = np.linspace(0.0, 310.0, total).reshape(shape)  # assuming in Kelvin
+    air_temp_cube.data = copy.copy(orig_temp)  # copy to test data is modified
+
+    heaviside_uv_cube.shape = shape
+    heaviside_uv_cube.data = np.linspace(0.0, 1.0, total).reshape(shape)
+    default_hcrit = 0.5
+
+    um2nc.apply_mask(air_temp_cube, heaviside_uv_cube, default_hcrit)
+
+    # TODO: how to test the outputs & masked, non-masked?
+    assert np.any(air_temp_cube.data != orig_temp)
 
 
 def test_to_stash_code():

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -15,6 +15,9 @@ import mule.ff
 import iris.cube
 
 
+DEFAULT_HCRIT = 0.5
+
+
 @pytest.fixture
 def z_sea_rho_data():
     # data ripped from aiihca.paa1jan.subset: ff.level_dependent_constants.zsea_at_rho
@@ -282,9 +285,8 @@ def test_apply_mask_with_matching_grid_extents(air_temp_cube, heaviside_uv_cube)
 
     heaviside_uv_cube.shape = shape
     heaviside_uv_cube.data = np.linspace(0.0, 1.0, total).reshape(shape)
-    default_hcrit = 0.5
 
-    um2nc.apply_mask(air_temp_cube, heaviside_uv_cube, default_hcrit)
+    um2nc.apply_mask(air_temp_cube, heaviside_uv_cube, DEFAULT_HCRIT)
 
     # TODO: how to test the outputs & masked, non-masked?
     assert np.any(air_temp_cube.data != orig_temp)


### PR DESCRIPTION
This PR is for initial work on retrofitting unit tests to `apply_mask()`.

As of the first few commits, the work is incomplete. Therefore, this PR is intended for discussions around design & retrofitting testing to iteratively improve the retro-fix approach. 

Interlinked problems exist with retro-fitting testing to this codebase:
* Production code depends upon `iris.cube.Cube` objects.
* `iris.cube.Cube`s need to be read from files
* `iris.cube.Cube`s are complex data structures, with production code accessing multiple `Cube` attrs
* Avoiding I/O (e.g. loading UM files) in low level unit tests
* Simulating `Cube`s wtih mocks requires tricky/fragile work to build nested data structures

**Fixes Required:**

`test_apply_mask_with_matching_grid_extents()`:
* the final assertions are weak & incomplete, only checking for data modification. Does this need more detailed tests to ensure the algorithm works as expected?
* Use `np.where()`?

`test_apply_mask_with_non_matching_grid_extents()`:
* relies on fragile mocking to synthesise cube attrs. Is there a way to create/ a synthetic cube from real data & skip mocking?
* also has weak assertions
