### PR TITLE
Test & refactor `fix_cell_methods()`

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -652,6 +652,8 @@ def test_fix_units_do_nothing_no_um_units(ua_plev_cube):
 
 
 def test_fix_cell_methods_drop_hours():
+    # ensure cell methods with "hour" in the interval name are translated to
+    # empty intervals
     cm = iris.coords.CellMethod("mean", "time", "3 hour")
     modified = um2nc.fix_cell_methods((cm,))
     assert len(modified) == 1
@@ -663,6 +665,7 @@ def test_fix_cell_methods_drop_hours():
 
 
 def test_fix_cell_methods_keep_weeks():
+    # ensure cell methods with non "hour" intervals are left as is
     cm = iris.coords.CellMethod("mean", "time", "week")
     modified = um2nc.fix_cell_methods((cm,))
     assert len(modified) == 1

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -10,6 +10,7 @@ import numpy as np
 import mule
 import mule.ff
 import iris.cube
+import iris.coords
 
 
 @pytest.fixture
@@ -648,3 +649,25 @@ def test_fix_units_do_nothing_no_um_units(ua_plev_cube):
     for unit in ("", None):
         um2nc.fix_units(ua_plev_cube, unit, verbose=False)
         assert ua_plev_cube.units == orig  # nothing should happen as there's no cube.units
+
+
+def test_fix_cell_methods_drop_hours():
+    cm = iris.coords.CellMethod("mean", "time", "3 hour")
+    modified = um2nc.fix_cell_methods((cm,))
+    assert len(modified) == 1
+
+    mod = modified[0]
+    assert mod.method == cm.method
+    assert mod.coord_names == cm.coord_names
+    assert mod.intervals == ()
+
+
+def test_fix_cell_methods_keep_weeks():
+    cm = iris.coords.CellMethod("mean", "time", "week")
+    modified = um2nc.fix_cell_methods((cm,))
+    assert len(modified) == 1
+
+    mod = modified[0]
+    assert mod.method == cm.method
+    assert mod.coord_names == cm.coord_names
+    assert mod.intervals[0] == "week"

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -266,18 +266,13 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
         sman.write(cube, zlib=True, complevel=compression, fill_value=fill_value)
 
 
-def fix_cell_methods(mtuple):
-    # Input is tuple of cell methods
-    newm = []
-    for m in mtuple:
-        newi = []
-        for i in m.intervals:
-            # Skip the misleading hour intervals
-            if i.find('hour') == -1:
-                newi.append(i)
-        n = CellMethod(m.method, m.coord_names, tuple(newi), m.comments)
-        newm.append(n)
-    return tuple(newm)
+def fix_cell_methods(cell_methods):
+    return tuple(CellMethod(m.method, m.coord_names, _remove_hour_interval(m), m.comments)
+                 for m in cell_methods)
+
+
+def _remove_hour_interval(cell_method):
+    return (i for i in cell_method.intervals if i.find('hour') == -1)
 
 
 def apply_mask(c, heaviside, hcrit):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -267,11 +267,25 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
 
 
 def fix_cell_methods(cell_methods):
+    """
+    Removes misleading 'hour' from interval naming, leaving other names intact.
+
+    TODO: is this an iris bug?
+
+    Parameters
+    ----------
+    cell_methods : the cell methods from a Cube (usually a tuple)
+
+    Returns
+    -------
+    A tuple of cell methods, with "hour" removed from interval names
+    """
     return tuple(CellMethod(m.method, m.coord_names, _remove_hour_interval(m), m.comments)
                  for m in cell_methods)
 
 
 def _remove_hour_interval(cell_method):
+    """Helper retains all non 'hour' intervals."""
     return (i for i in cell_method.intervals if i.find('hour') == -1)
 
 


### PR DESCRIPTION
This small PR adds tests to `fix_cell_methods()` & replaces old manual looping logic.

I haven't explicitly tested multiple cell methods in a `cube.cell_methods` attr. From examining the `aiihca.paa1jan.subset` data file, there's always only 1 cell method in the `cube.cell_methods` sequence for each cube.

Any comments on the new code style, correctness & gaps is welcome :-)
