### PR TITLE
Refactor `process()` I/O / operation order

### DIFF
--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -341,12 +341,11 @@ def process(infile, outfile, args):
 
     # cube processing & modification
     for c in cubes:
-        umvar = stashvar.StashVar(c.item_code)  # TODO: rename with `stash` as it's from stash codes
-
-        fix_var_name(c, umvar.uniquename, args.simple)
-        fix_standard_name(c, umvar.standard_name, args.verbose)
-        fix_long_name(c, umvar.long_name)
-        fix_units(c, umvar.units, args.verbose)
+        st = stashvar.StashVar(c.item_code)
+        fix_var_name(c, st.uniquename, args.simple)
+        fix_standard_name(c, st.standard_name, args.verbose)
+        fix_long_name(c, st.long_name)
+        fix_units(c, st.units, args.verbose)
 
         # Interval in cell methods isn't reliable so better to remove it.
         c.cell_methods = fix_cell_methods(c.cell_methods)


### PR DESCRIPTION
Resolves #75. 

This is a quick PR to reorder `process()` into 3 chunks: input I/O, cube mods & output I/O. It is mainly to help readability & structure for retro-fixing `cubewrite()`.

The tests pass locally on my machine & a couple of command line tests show the outputs from this are still a binary match to the very 1st commit in this repo.

Comments welcome :-)