### PR TITLE
Split main into separate function and add entry point

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -93,6 +93,10 @@ jobs:
         shell: bash -l {0}
         run: pylint --extension-pkg-whitelist=netCDF4 --ignored-modules=umpost -E umpost
 
+      - name: Entrypoint test
+        shell: bash -l {0}
+        run: esm1p5_convert_nc --help
+
       - name: Run tests
         shell: bash -l {0}
         run: python -m pytest --cov=umpost --cov-report=xml -s test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install conda package
         shell: bash -l {0}
         run: |
-          conda install -c conda-forge -c accessnri -c coecms -c file://${{ env.ARTIFACT_LOCATION }} um2nc
+          conda install -c file://${{ env.ARTIFACT_LOCATION }} -c conda-forge -c accessnri -c coecms um2nc
 
       - name: List installed packages
         shell: bash -l {0}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.scripts]
-esm1p5_convert_nc = "um2netcdf-standalone.umpost.conversion_driver_esm1p5:main"
+esm1p5_convert_nc = "um2nc-standalone.umpost.conversion_driver_esm1p5:main"
 
 [tool.versioneer]
 VCS = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.scripts]
-esm1p5_convert_nc = "umpost.conversion_driver_esm1p5:main"
+esm1p5_convert_nc = "um2nc.umpost.conversion_driver_esm1p5:main"
 
 [tool.versioneer]
 VCS = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
   "f90nml",
 ]
 
+[project.scripts]
+esm1p5_convert_nc = "umpost.conversion_driver_esm1p5:main"
+
 [tool.versioneer]
 VCS = "git"
 style = "pep440"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.scripts]
-esm1p5_convert_nc = "um2nc.umpost.conversion_driver_esm1p5:main"
+esm1p5_convert_nc = "um2netcdf-standalone.umpost.conversion_driver_esm1p5:main"
 
 [tool.versioneer]
 VCS = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 ]
 
 [project.scripts]
-esm1p5_convert_nc = "um2nc-standalone.umpost.conversion_driver_esm1p5:main"
+esm1p5_convert_nc = "umpost.conversion_driver_esm1p5:main"
 
 [tool.versioneer]
 VCS = "git"

--- a/umpost/conversion_driver_esm1p5.py
+++ b/umpost/conversion_driver_esm1p5.py
@@ -12,6 +12,7 @@ https://github.com/ACCESS-NRI/access-cm2-drivers/blob/main/src/run_um2netcdf.py
 
 
 import os
+import sys
 import collections
 import re
 import f90nml
@@ -295,25 +296,36 @@ def safe_removal(succeeded, failed):
     return succeeded_inputs - failed_inputs
 
 
-if __name__ == "__main__":
+def parse_args(args):
+    """
+    Parse arguments given as list (args)
+    """
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "current_output_dir", help="ESM1.5 output directory to be converted", type=str
+        "current_output_dir", help="ESM1.5 output directory to be converted",
+        type=str
     )
     parser.add_argument("--quiet", "-q", action="store_true",
                         help=(
-                            "Report only final exception type and message for allowed"
-                            "exceptions raised during conversion when flag is included."
-                            "Otherwise report full stack trace."
+                            "Report only final exception type and message for "
+                            "allowed exceptions raised during conversion when "
+                            "flag is included. Otherwise report full "
+                            "stack trace."
                         )
                         )
     parser.add_argument("--delete-ff", "-d", action="store_true",
                         help="Delete fields files upon successful conversion."
                         )
-    args = parser.parse_args()
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args(sys.argv[1:])
 
     current_output_dir = args.current_output_dir
 
+    # Run conversion
     successes, failures = convert_esm1p5_output_dir(current_output_dir)
 
     # Report results to user
@@ -326,3 +338,8 @@ if __name__ == "__main__":
         # Remove files that appear only as successful conversions
         for path in safe_removal(successes, failures):
             os.remove(path)
+
+
+if __name__ == "__main__":
+
+    main()

--- a/umpost/conversion_driver_esm1p5.py
+++ b/umpost/conversion_driver_esm1p5.py
@@ -12,7 +12,6 @@ https://github.com/ACCESS-NRI/access-cm2-drivers/blob/main/src/run_um2netcdf.py
 
 
 import os
-import sys
 import collections
 import re
 import f90nml
@@ -296,7 +295,7 @@ def safe_removal(succeeded, failed):
     return succeeded_inputs - failed_inputs
 
 
-def parse_args(args):
+def parse_args():
     """
     Parse arguments given as list (args)
     """
@@ -321,7 +320,7 @@ def parse_args(args):
 
 
 def main():
-    args = parse_args(sys.argv[1:])
+    args = parse_args()
 
     current_output_dir = args.current_output_dir
 

--- a/umpost/conversion_driver_esm1p5.py
+++ b/umpost/conversion_driver_esm1p5.py
@@ -321,11 +321,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-
-    current_output_dir = args.current_output_dir
-
-    # Run conversion
-    successes, failures = convert_esm1p5_output_dir(current_output_dir)
+    successes, failures = convert_esm1p5_output_dir(args.current_output_dir)
 
     # Report results to user
     for success_message in format_successes(successes):


### PR DESCRIPTION
This PR addresses the ESM1.5 conversion driver part of #81, splitting the `main` block into separate `main()` and `parse_args()` functions, which allows for an entry point to be added to the `pytproject.toml` file. 

Adding entry points to `um2netcdf` will be addressed separately in #82. 

I'm unsure how to test that the entry point is working, and so suggestions on that would be great too!