### PR TITLE
Add un2nc `main()` entry point

### DIFF
--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -761,6 +761,10 @@ def parse_args():
     return parser.parse_args()
 
 
-if __name__ == '__main__':
+def main():
     args = parse_args()
     process(args.infile, args.outfile, args)
+
+
+if __name__ == '__main__':
+    main()

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -722,7 +722,7 @@ def fix_units(cube, um_var_units, verbose: bool):
             cube.units = um_var_units
 
 
-if __name__ == '__main__':
+def parse_args():
     parser = argparse.ArgumentParser(description="Convert UM fieldsfile to netcdf")
     parser.add_argument('-k', dest='nckind', required=False, type=int,
                         default=3,
@@ -758,5 +758,9 @@ if __name__ == '__main__':
     parser.add_argument('infile', help='Input file')
     parser.add_argument('outfile', help='Output file')
 
-    cli_args = parser.parse_args()
-    process(cli_args.infile, cli_args.outfile, cli_args)
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    process(args.infile, args.outfile, args)


### PR DESCRIPTION
This PR adds a `main()` function & entry point to `um2netcdf`. The unit tests pass on my system, as do some manual tests of the command line script to convert a test file.

Known Gaps:
* I skipped adding even a very basic unit test, although this can be addressed in future tidying work.
* Running a CI test of `um2netcdf --help` is missing from this. I can add it to this PR or push out to a smaller sub issue.

Any comments welcome!