### PR TITLE
Add tests/clean `fix_level_coord()`

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -677,7 +677,9 @@ def test_fix_cell_methods_keep_weeks():
     assert mod.intervals[0] == "week"
 
 
-LEVEL_HEIGHTS = [20.0003377]  # NB: technically only need [0]
+# NB: sourced from z_sea_theta_data fixture. This "array" is cropped as
+#     fix_level_coords() only accesses height array[0]
+LEVEL_HEIGHTS = [20.0003377]
 
 LEVEL_COORDS = {um2nc.MODEL_LEVEL_NUM: iris.coords.DimCoord(range(1, 39)),
                 um2nc.LEVEL_HEIGHT: iris.coords.DimCoord(LEVEL_HEIGHTS),
@@ -691,7 +693,8 @@ class FakeCubeCoords:
         return LEVEL_COORDS[key]
 
 
-def test_fix_level_coord_rho(z_sea_rho_data, z_sea_theta_data):
+def test_fix_level_coord_modify_cube_with_rho(z_sea_rho_data, z_sea_theta_data):
+    # verify cube renaming with appropriate z_rho data
     assert LEVEL_COORDS[um2nc.MODEL_LEVEL_NUM].var_name is None
     assert LEVEL_COORDS[um2nc.LEVEL_HEIGHT].var_name is None
     assert LEVEL_COORDS[um2nc.SIGMA].var_name is None
@@ -705,7 +708,8 @@ def test_fix_level_coord_rho(z_sea_rho_data, z_sea_theta_data):
     assert LEVEL_COORDS[um2nc.SIGMA].var_name == "sigma_rho"
 
 
-def test_fix_level_coord_theta(z_sea_rho_data, z_sea_theta_data):
+def test_fix_level_coord_modify_cube_with_theta(z_sea_rho_data, z_sea_theta_data):
+    # verify cube renaming with appropriate z_theta data
     cube = FakeCubeCoords()
     um2nc.fix_level_coord(cube, z_sea_rho_data, z_sea_theta_data)
 
@@ -714,7 +718,8 @@ def test_fix_level_coord_theta(z_sea_rho_data, z_sea_theta_data):
     assert LEVEL_COORDS[um2nc.SIGMA].var_name == "sigma_theta"
 
 
-def test_fix_level_coord_not_found(z_sea_rho_data, z_sea_theta_data):
+def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):
+    # ensures level fixes are skipped if the cube lacks model levels, sigma etc
     mcube = mock.Mock(iris.cube.Cube)
     mcube.coord.side_effect = iris.exceptions.CoordinateNotFoundError
     um2nc.fix_level_coord(mcube, z_sea_rho_data, z_sea_theta_data)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -700,7 +700,18 @@ def fix_units(cube, um_var_units, verbose: bool):
 
 
 def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
-    # Rename model_level_number coordinates to better distinguish rho and theta levels
+    """
+    Renames model_level_number coordinates to help distinguish rho/theta levels.
+
+    Cubes without 'model_level_number' coordinates are skipped.
+
+    Parameters
+    ----------
+    cube : iris.cube.Cube object to
+    z_rho : geopotential height of the sea free surface
+    z_theta : density (rho) of the air at sea level
+    tol : height tolerance
+    """
     try:
         c_lev = cube.coord(MODEL_LEVEL_NUM)
         c_height = cube.coord(LEVEL_HEIGHT)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -712,6 +712,9 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
     z_theta : density (rho) of the air at sea level
     tol : height tolerance
     """
+    # TODO: this is called once per cube and many lack the model_level_number
+    #       coord. Is a potential optimisation possible from pre-specifying a
+    #       list of cubes with model_level_numbers & only processing these?
     try:
         c_lev = cube.coord(MODEL_LEVEL_NUM)
         c_height = cube.coord(LEVEL_HEIGHT)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -145,17 +145,15 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
         lon.var_name = 'lon'
 
 
-# TODO: move this to func renaming section?
+# TODO: move this func lower down
 def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
     # Rename model_level_number coordinates to better distinguish rho and theta levels
     try:
-        c_lev = cube.coord('model_level_number')
-        c_height = cube.coord('level_height')
-        c_sigma = cube.coord('sigma')
+        c_lev = cube.coord(MODEL_LEVEL_NUM)
+        c_height = cube.coord(LEVEL_HEIGHT)
+        c_sigma = cube.coord(SIGMA)
     except iris.exceptions.CoordinateNotFoundError:
-        c_lev = None
-        c_height = None
-        c_sigma = None
+        return
 
     if c_lev:
         d_rho = abs(c_height.points[0]-z_rho)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -145,30 +145,6 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
         lon.var_name = 'lon'
 
 
-# TODO: move this func lower down
-def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
-    # Rename model_level_number coordinates to better distinguish rho and theta levels
-    try:
-        c_lev = cube.coord(MODEL_LEVEL_NUM)
-        c_height = cube.coord(LEVEL_HEIGHT)
-        c_sigma = cube.coord(SIGMA)
-    except iris.exceptions.CoordinateNotFoundError:
-        return
-
-    if c_lev:
-        d_rho = abs(c_height.points[0]-z_rho)
-        if d_rho.min() < tol:
-            c_lev.var_name = 'model_rho_level_number'
-            c_height.var_name = 'rho_level_height'
-            c_sigma.var_name = 'sigma_rho'
-        else:
-            d_theta = abs(c_height.points[0]-z_theta)
-            if d_theta.min() < tol:
-                c_lev.var_name = 'model_theta_level_number'
-                c_height.var_name = 'theta_level_height'
-                c_sigma.var_name = 'sigma_theta'
-
-
 # TODO: split cube ops into functions, this will likely increase process() workflow steps
 def cubewrite(cube, sman, compression, use64bit, verbose):
     try:
@@ -721,6 +697,29 @@ def fix_units(cube, um_var_units, verbose: bool):
                 msg = f"Units mismatch {cube.item_code} {cube.units} {um_var_units}"
                 warnings.warn(msg)
             cube.units = um_var_units
+
+
+def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
+    # Rename model_level_number coordinates to better distinguish rho and theta levels
+    try:
+        c_lev = cube.coord(MODEL_LEVEL_NUM)
+        c_height = cube.coord(LEVEL_HEIGHT)
+        c_sigma = cube.coord(SIGMA)
+    except iris.exceptions.CoordinateNotFoundError:
+        return
+
+    if c_lev:
+        d_rho = abs(c_height.points[0]-z_rho)
+        if d_rho.min() < tol:
+            c_lev.var_name = 'model_rho_level_number'
+            c_height.var_name = 'rho_level_height'
+            c_sigma.var_name = 'sigma_rho'
+        else:
+            d_theta = abs(c_height.points[0]-z_theta)
+            if d_theta.min() < tol:
+                c_lev.var_name = 'model_theta_level_number'
+                c_height.var_name = 'theta_level_height'
+                c_sigma.var_name = 'sigma_theta'
 
 
 def parse_args():

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -707,7 +707,7 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
 
     Parameters
     ----------
-    cube : iris.cube.Cube object to
+    cube : iris.cube.Cube object for in place modification
     z_rho : geopotential height of the sea free surface
     z_theta : density (rho) of the air at sea level
     tol : height tolerance

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -47,6 +47,10 @@ NC_FORMATS = {
     4: 'NETCDF4_CLASSIC'
 }
 
+MODEL_LEVEL_NUM = "model_level_number"
+LEVEL_HEIGHT = "level_height"
+SIGMA = "sigma"
+
 
 class PostProcessingError(Exception):
     """Generic class for um2nc specific errors."""

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -145,9 +145,8 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
         lon.var_name = 'lon'
 
 
-# TODO: refactor to "rename level coord"
 # TODO: move this to func renaming section?
-def fix_level_coord(cube, z_rho, z_theta):
+def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
     # Rename model_level_number coordinates to better distinguish rho and theta levels
     try:
         c_lev = cube.coord('model_level_number')
@@ -160,13 +159,13 @@ def fix_level_coord(cube, z_rho, z_theta):
 
     if c_lev:
         d_rho = abs(c_height.points[0]-z_rho)
-        if d_rho.min() < 1e-6:
+        if d_rho.min() < tol:
             c_lev.var_name = 'model_rho_level_number'
             c_height.var_name = 'rho_level_height'
             c_sigma.var_name = 'sigma_rho'
         else:
             d_theta = abs(c_height.points[0]-z_theta)
-            if d_theta.min() < 1e-6:
+            if d_theta.min() < tol:
                 c_lev.var_name = 'model_theta_level_number'
                 c_height.var_name = 'theta_level_height'
                 c_sigma.var_name = 'sigma_theta'


### PR DESCRIPTION
Closes #53. Note, this PR is merges to `main`.

This PR:
* adds unit tests for `fix_level_coord()`
* moves the function down to call order (i.e. below `process()`)
* Cleans the code slightly

These tests use `iris` coordinate objects to avoid mocks cube attributes. Based on this experiment, this could be a reasonable approach for other tests requiring `iris` coordinates.

Any comments welcome!