### PR TITLE
92/Refactor pressure level modifications

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
 branch = True
 
+# skip coverage testing for external source files
+omit = umpost/_version.py
+
 [html]
 title = Coverage report: um2nc-standalone
 directory = coverage_html

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -759,7 +759,7 @@ def test_fix_plevs_no_pressure_coord(get_fake_cube_coords):
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         cube.coord("pressure")  # ensure missing 'pressure' coord
 
-    um2nc.fix_plevs(cube)  # should just exit
+    um2nc.fix_pressure_levels(cube)  # should just exit
 
 
 def _add_attrs_points(m_plevs: mock.MagicMock, points):
@@ -775,7 +775,7 @@ def test_fix_plevs_do_rounding(get_fake_cube_coords):
     extra = {"pressure": m_plevs}
     cube = get_fake_cube_coords(extra)
 
-    um2nc.fix_plevs(cube)
+    um2nc.fix_pressure_levels(cube)
 
     # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
     #       returning a new cube if the pressure is reversed. This is verified
@@ -792,7 +792,7 @@ def test_fix_plevs_reverse_pressure(get_fake_cube_coords):
     cube = get_fake_cube_coords(extra)
 
     with mock.patch("iris.util.reverse"):
-        um2nc.fix_plevs(cube)
+        um2nc.fix_pressure_levels(cube)
 
     # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
     #       returning a new cube if the pressure is reversed. This is verified

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -777,6 +777,9 @@ def test_fix_plevs_do_rounding(get_fake_cube_coords):
 
     um2nc.fix_plevs(cube)
 
+    # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
+    #       returning a new cube if the pressure is reversed. This is verified
+    #       in command line testing though
     plev = cube.coord('pressure')
     assert plev.attributes["positive"] == "down"
     assert all(plev.points == [1.0, 0.0])
@@ -791,6 +794,9 @@ def test_fix_plevs_reverse_pressure(get_fake_cube_coords):
     with mock.patch("iris.util.reverse"):
         um2nc.fix_plevs(cube)
 
+    # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
+    #       returning a new cube if the pressure is reversed. This is verified
+    #       in command line testing though
     plev = cube.coord('pressure')
     assert plev.attributes["positive"] == "down"
     assert all(plev.points == [0.0, 1.0])

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -753,7 +753,7 @@ def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):
 
 # tests - fix pressure level data
 
-def test_fix_plevs_no_pressure_coord(get_fake_cube_coords):
+def test_fix_pressure_levels_no_pressure_coord(get_fake_cube_coords):
     cube = get_fake_cube_coords()
 
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
@@ -769,10 +769,10 @@ def _add_attrs_points(m_plevs: mock.MagicMock, points):
     setattr(m_plevs, "points", points)
 
 
-def test_fix_plevs_do_rounding(get_fake_cube_coords):
-    m_plevs = mock.Mock()
-    _add_attrs_points(m_plevs, [1.000001, 0.000001])
-    extra = {"pressure": m_plevs}
+def test_fix_pressure_levels_do_rounding(get_fake_cube_coords):
+    m_pressure = mock.Mock()
+    _add_attrs_points(m_pressure, [1.000001, 0.000001])
+    extra = {"pressure": m_pressure}
     cube = get_fake_cube_coords(extra)
 
     um2nc.fix_pressure_levels(cube)
@@ -780,15 +780,15 @@ def test_fix_plevs_do_rounding(get_fake_cube_coords):
     # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
     #       returning a new cube if the pressure is reversed. This is verified
     #       in command line testing though
-    plev = cube.coord('pressure')
-    assert plev.attributes["positive"] == "down"
-    assert all(plev.points == [1.0, 0.0])
+    c_pressure = cube.coord('pressure')
+    assert c_pressure.attributes["positive"] == "down"
+    assert all(c_pressure.points == [1.0, 0.0])
 
 
-def test_fix_plevs_reverse_pressure(get_fake_cube_coords):
-    m_plevs = mock.Mock()
-    _add_attrs_points(m_plevs, [0.000001, 1.000001])
-    extra = {"pressure": m_plevs}
+def test_fix_pressure_levels_reverse_pressure(get_fake_cube_coords):
+    m_pressure = mock.Mock()
+    _add_attrs_points(m_pressure, [0.000001, 1.000001])
+    extra = {"pressure": m_pressure}
     cube = get_fake_cube_coords(extra)
 
     with mock.patch("iris.util.reverse"):
@@ -797,6 +797,6 @@ def test_fix_plevs_reverse_pressure(get_fake_cube_coords):
     # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
     #       returning a new cube if the pressure is reversed. This is verified
     #       in command line testing though
-    plev = cube.coord('pressure')
-    assert plev.attributes["positive"] == "down"
-    assert all(plev.points == [0.0, 1.0])
+    c_pressure = cube.coord('pressure')
+    assert c_pressure.attributes["positive"] == "down"
+    assert all(c_pressure.points == [0.0, 1.0])

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -777,7 +777,7 @@ def test_fix_pressure_levels_do_rounding(get_fake_cube_coords):
 
     um2nc.fix_pressure_levels(cube)
 
-    # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
+    # TODO: test flaw, this verifies pressure coord but ignores fix_pressure_levels()
     #       returning a new cube if the pressure is reversed. This is verified
     #       in command line testing though
     c_pressure = cube.coord('pressure')
@@ -794,7 +794,7 @@ def test_fix_pressure_levels_reverse_pressure(get_fake_cube_coords):
     with mock.patch("iris.util.reverse"):
         um2nc.fix_pressure_levels(cube)
 
-    # TODO: test flaw, this verifies pressure coord but ignores fix_plevs()
+    # TODO: test flaw, this verifies pressure coord but ignores fix_pressure_levels()
     #       returning a new cube if the pressure is reversed. This is verified
     #       in command line testing though
     c_pressure = cube.coord('pressure')

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -761,7 +761,8 @@ def test_fix_pressure_levels_no_pressure_coord(get_fake_cube_coords):
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         cube.coord("pressure")  # ensure missing 'pressure' coord
 
-    um2nc.fix_pressure_levels(cube)  # should just exit
+    # fix function should return if there is no pressure coord to modify
+    assert um2nc.fix_pressure_levels(cube) is None  # should just exit
 
 
 def _add_attrs_points(m_plevs: mock.MagicMock, points):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -788,9 +788,7 @@ def test_fix_pressure_levels_do_rounding(get_fake_cube_coords):
 
 @pytest.mark.skip
 def test_fix_pressure_levels_reverse_pressure(get_fake_cube_coords):
-    # TODO: test is broken, it verifies the pressure coord but doesn't handle
-    #       the real fix_pressure_levels() returning a new cube when the pressure
-    #       is reversed.
+    # TODO: test is broken due to fiddly mocking problems (see below)
 
     m_pressure = mock.Mock()
     # m_pressure.ndim = 1

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -683,11 +683,13 @@ def level_heights():
     #     fix_level_coords() only accesses height array[0]
     return [20.0003377]
 
+
 @pytest.fixture
 def level_coords(level_heights):
     return {um2nc.MODEL_LEVEL_NUM: iris.coords.DimCoord(range(1, 39)),
             um2nc.LEVEL_HEIGHT: iris.coords.DimCoord(level_heights),
             um2nc.SIGMA: iris.coords.AuxCoord(np.array([0.99771646]))}
+
 
 @pytest.fixture
 def get_fake_cube_coords(level_coords):
@@ -695,6 +697,10 @@ def get_fake_cube_coords(level_coords):
     @dataclass
     class FakeCubeCoords:
         """Test object to represent a cube with a coords() access function."""
+
+        def __init__(self, custom_coord: dict = None):
+            if custom_coord:
+                level_coords.update(custom_coord)
 
         def coord(self, key):
             return level_coords[key]
@@ -712,7 +718,6 @@ def test_fix_level_coord_modify_cube_with_rho(level_heights,
     assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name is None
     assert cube.coord(um2nc.LEVEL_HEIGHT).var_name is None
     assert cube.coord(um2nc.SIGMA).var_name is None
-
 
     rho = np.ones(z_sea_theta_data.shape) * level_heights[0]
     um2nc.fix_level_coord(cube, rho, z_sea_theta_data)

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -778,7 +778,8 @@ def test_fix_pressure_levels_do_rounding(get_fake_cube_coords):
     extra = {"pressure": m_pressure}
     cube = get_fake_cube_coords(extra)
 
-    um2nc.fix_pressure_levels(cube)
+    # ensure no cube is returned if Cube not modified in fix_pressure_levels()
+    assert um2nc.fix_pressure_levels(cube) is None
 
     # TODO: test flaw, this verifies pressure coord but ignores fix_pressure_levels()
     #       returning a new cube if the pressure is reversed. This is verified

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -726,7 +726,7 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
                 c_sigma.var_name = 'sigma_theta'
 
 
-def fix_plevs(cube):
+def fix_plevs(cube, decimals=5):
     """
     Reformat pressure level data for NetCDF output.
 
@@ -736,13 +736,13 @@ def fix_plevs(cube):
     Parameters
     ----------
     cube : iris Cube (modifies in place)
+    decimals : number of decimals to round to
 
     Returns
     -------
     None if cube lacks pressure coord or is modified in place, otherwise a new
     cube if the pressure levels are reversed.
     """
-    # TODO: add rounding places arg
     try:
         plevs = cube.coord('pressure')
     except iris.exceptions.CoordinateNotFoundError:
@@ -753,7 +753,7 @@ def fix_plevs(cube):
     plevs.convert_units('Pa')
 
     # Round small fractions otherwise coordinates are off by 1e-10 in ncdump output
-    plevs.points = np.round(plevs.points, 5)
+    plevs.points = np.round(plevs.points, decimals)
 
     if plevs.points[0] < plevs.points[-1]:
         # Flip to get pressure decreasing as per CMIP6 standard

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -147,6 +147,7 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
 
 # TODO: split cube ops into functions, this will likely increase process() workflow steps
 def cubewrite(cube, sman, compression, use64bit, verbose):
+    # TODO: move into process() AND if a new cube is returned, swap into filtered cube list
     cube = fix_plevs(cube) or cube  # NB: use new cube if pressure points are modified
 
     if not use64bit:

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -148,7 +148,7 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
 # TODO: split cube ops into functions, this will likely increase process() workflow steps
 def cubewrite(cube, sman, compression, use64bit, verbose):
     # TODO: move into process() AND if a new cube is returned, swap into filtered cube list
-    cube = fix_plevs(cube) or cube  # NB: use new cube if pressure points are modified
+    cube = fix_pressure_levels(cube) or cube  # NB: use new cube if pressure points are modified
 
     if not use64bit:
         if cube.data.dtype == 'float64':
@@ -727,7 +727,7 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
                 c_sigma.var_name = 'sigma_theta'
 
 
-def fix_plevs(cube, decimals=5):
+def fix_pressure_levels(cube, decimals=5):
     """
     Reformat pressure level data for NetCDF output.
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -745,18 +745,18 @@ def fix_pressure_levels(cube, decimals=5):
     cube if the pressure levels are reversed.
     """
     try:
-        plevs = cube.coord('pressure')
+        pressure = cube.coord('pressure')
     except iris.exceptions.CoordinateNotFoundError:
         return
 
     # update existing cube metadata in place
-    plevs.attributes['positive'] = 'down'
-    plevs.convert_units('Pa')
+    pressure.attributes['positive'] = 'down'
+    pressure.convert_units('Pa')
 
     # Round small fractions otherwise coordinates are off by 1e-10 in ncdump output
-    plevs.points = np.round(plevs.points, decimals)
+    pressure.points = np.round(pressure.points, decimals)
 
-    if plevs.points[0] < plevs.points[-1]:
+    if pressure.points[0] < pressure.points[-1]:
         # Flip to get pressure decreasing as per CMIP6 standard
         # NOTE: returns a new cube!
         return iris.util.reverse(cube, 'pressure')

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -147,17 +147,7 @@ def fix_latlon_coord(cube, grid_type, dlat, dlon):
 
 # TODO: split cube ops into functions, this will likely increase process() workflow steps
 def cubewrite(cube, sman, compression, use64bit, verbose):
-    try:
-        plevs = cube.coord('pressure')
-        plevs.attributes['positive'] = 'down'
-        plevs.convert_units('Pa')
-        # Otherwise they're off by 1e-10 which looks odd in ncdump
-        plevs.points = np.round(plevs.points, 5)
-        if plevs.points[0] < plevs.points[-1]:
-            # Flip to get pressure decreasing as in CMIP6 standard
-            cube = iris.util.reverse(cube, 'pressure')
-    except iris.exceptions.CoordinateNotFoundError:
-        pass
+    fix_plevs(cube)
 
     if not use64bit:
         if cube.data.dtype == 'float64':
@@ -734,6 +724,27 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
                 c_lev.var_name = 'model_theta_level_number'
                 c_height.var_name = 'theta_level_height'
                 c_sigma.var_name = 'sigma_theta'
+
+
+def fix_plevs(cube):
+    """
+    TODO
+
+    Parameters
+    ----------
+    cube : iris Cube (modifies in place)
+    """
+    try:
+        plevs = cube.coord('pressure')
+        plevs.attributes['positive'] = 'down'
+        plevs.convert_units('Pa')
+        # Otherwise they're off by 1e-10 which looks odd in ncdump
+        plevs.points = np.round(plevs.points, 5)
+        if plevs.points[0] < plevs.points[-1]:
+            # Flip to get pressure decreasing as in CMIP6 standard
+            cube = iris.util.reverse(cube, 'pressure')
+    except iris.exceptions.CoordinateNotFoundError:
+        pass
 
 
 def parse_args():

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -757,6 +757,7 @@ def fix_pressure_levels(cube, decimals=5):
     if pressure.points[0] < pressure.points[-1]:
         # Flip to get pressure decreasing as per CMIP6 standard
         # NOTE: returns a new cube!
+        # TODO: add an iris.util.monotonic() check here?
         return iris.util.reverse(cube, 'pressure')
 
 


### PR DESCRIPTION
Resolves #92.

This PR covers a few tasks:
* extracts pressure level modification functionality to a standalone function
* adds partial unit testing
* rearranges the `um2netcdf` module slightly
* partial code cleanup

**Known gaps:**

This work exposes a (possibly one off) case where `iris` funcs return a _new_ cube. Moving the pressure level fixes into `process()` requires modifying the list of cubes being processed to patch the new cube in. This is noted in the code. The tests are also moderately loose, related to the complexity with testing `iris` components.

It's likely addressing this will have to be deferred until the code is restructured & tested, to allow workflow refactoring.

Otherwise, any comments welcome!