### PR TITLE
Clean, test & refactor 64 to 32 bit conversion step.

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -744,6 +744,7 @@ def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):
 
 
 # 64 to 32 bit data conversion tests
+# NB: skip float63 to float32 overflow as float32 min/max is  -/+ 3.40e+38
 
 def test_convert_32_bit_with_int64(ua_plev_cube):
     array = np.array([100, 10, 1, 0, -10], dtype=np.int64)
@@ -774,7 +775,7 @@ def test_convert_32_bit_underflow_with_int64(ua_plev_cube):
     assert ua_plev_cube.data.dtype == np.int32
 
 
-def test_64_to_32_float(ua_plev_cube):
+def test_convert_32_bit_with_float64(ua_plev_cube):
     array = np.array([300.33, 30.456, 3.04, 0.0, -30.667], dtype=np.float64)
     ua_plev_cube.data = array
     um2nc.convert_32_bit(ua_plev_cube)

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -397,6 +397,7 @@ class DummyCube:
         self.standard_name = None
         self.long_name = None
         self.coord = {}
+        self.data = None
 
     def name(self):
         # mimic iris API
@@ -740,3 +741,19 @@ def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):
     m_cube = mock.Mock(iris.cube.Cube)
     m_cube.coord.side_effect = iris.exceptions.CoordinateNotFoundError
     um2nc.fix_level_coord(m_cube, z_sea_rho_data, z_sea_theta_data)
+
+
+# 64 to 32 bit data conversion tests
+
+def test_64_to_32_int(ua_plev_cube):
+    array = np.array([100, 10, 1, 0, -10], dtype=np.int64)
+    ua_plev_cube.data = array
+    um2nc.convert_32_bit(ua_plev_cube)
+    assert ua_plev_cube.data.dtype == np.int32
+
+
+def test_64_to_32_float(ua_plev_cube):
+    array = np.array([300.33, 30.456, 3.04, 0.0, -30.667], dtype=np.float64)
+    ua_plev_cube.data = array
+    um2nc.convert_32_bit(ua_plev_cube)
+    assert ua_plev_cube.data.dtype == np.float32

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -745,10 +745,32 @@ def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):
 
 # 64 to 32 bit data conversion tests
 
-def test_64_to_32_int(ua_plev_cube):
+def test_convert_32_bit_with_int64(ua_plev_cube):
     array = np.array([100, 10, 1, 0, -10], dtype=np.int64)
     ua_plev_cube.data = array
     um2nc.convert_32_bit(ua_plev_cube)
+    assert ua_plev_cube.data.dtype == np.int32
+
+
+def test_convert_32_bit_overflow_with_int64(ua_plev_cube):
+    array = np.array([3000000000], dtype=np.int64)
+    assert array[0] > np.iinfo(np.int32).max
+    ua_plev_cube.data = array
+
+    with pytest.warns():
+        um2nc.convert_32_bit(ua_plev_cube)
+
+    assert ua_plev_cube.data.dtype == np.int32
+
+
+def test_convert_32_bit_underflow_with_int64(ua_plev_cube):
+    array = np.array([-3000000000], dtype=np.int64)
+    assert array[0] < np.iinfo(np.int32).max
+    ua_plev_cube.data = array
+
+    with pytest.warns():
+        um2nc.convert_32_bit(ua_plev_cube)
+
     assert ua_plev_cube.data.dtype == np.int32
 
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -753,10 +753,10 @@ def convert_32_bit(cube):
 
         if _max > MAX_NP_INT32:
             msg = f"Converting {cube.var_name} causes a 32 bit overflow!"
-            warnings.warn(msg)
+            warnings.warn(msg, category=RuntimeWarning)
         elif _min < MIN_NP_INT32:
             msg = f"Converting {cube.var_name} causes a 32 bit underflow!"
-            warnings.warn(msg)
+            warnings.warn(msg, category=RuntimeWarning)
 
         cube.data = cube.data.astype(np.int32)
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -160,10 +160,7 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
         pass
 
     if not use64bit:
-        if cube.data.dtype == 'float64':
-            cube.data = cube.data.astype(np.float32)
-        elif cube.data.dtype == 'int64':
-            cube.data = cube.data.astype(np.int32)
+        convert_32_bit(cube)
 
     # Set the missing_value attribute. Use an array to force the type to match
     # the data type
@@ -734,6 +731,13 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
                 c_lev.var_name = 'model_theta_level_number'
                 c_height.var_name = 'theta_level_height'
                 c_sigma.var_name = 'sigma_theta'
+
+
+def convert_32_bit(cube):
+    if cube.data.dtype == 'float64':
+        cube.data = cube.data.astype(np.float32)
+    elif cube.data.dtype == 'int64':
+        cube.data = cube.data.astype(np.int32)
 
 
 def parse_args():

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -738,6 +738,13 @@ MIN_NP_INT32 = np.iinfo(np.int32).min
 
 
 def convert_32_bit(cube):
+    """
+    Convert 64 bit int/float data to 32 bit (in place).
+
+    Parameters
+    ----------
+    cube : iris.cube object to modify.
+    """
     if cube.data.dtype == 'float64':
         cube.data = cube.data.astype(np.float32)
     elif cube.data.dtype == 'int64':

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -744,6 +744,10 @@ def convert_32_bit(cube):
     Parameters
     ----------
     cube : iris.cube object to modify.
+
+    Warns
+    -----
+    RuntimeWarning : if the cube has data over 32-bit limits, causing an overflow.
     """
     if cube.data.dtype == 'float64':
         cube.data = cube.data.astype(np.float32)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -733,10 +733,24 @@ def fix_level_coord(cube, z_rho, z_theta, tol=1e-6):
                 c_sigma.var_name = 'sigma_theta'
 
 
+MAX_NP_INT32 = np.iinfo(np.int32).max
+MIN_NP_INT32 = np.iinfo(np.int32).min
+
+
 def convert_32_bit(cube):
     if cube.data.dtype == 'float64':
         cube.data = cube.data.astype(np.float32)
     elif cube.data.dtype == 'int64':
+        _max = np.max(cube.data)
+        _min = np.min(cube.data)
+
+        if _max > MAX_NP_INT32:
+            msg = f"Converting {cube.var_name} causes a 32 bit overflow!"
+            warnings.warn(msg)
+        elif _min < MIN_NP_INT32:
+            msg = f"Converting {cube.var_name} causes a 32 bit underflow!"
+            warnings.warn(msg)
+
         cube.data = cube.data.astype(np.int32)
 
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -755,12 +755,13 @@ def convert_32_bit(cube):
         _max = np.max(cube.data)
         _min = np.min(cube.data)
 
+        msg = (f"32 bit under/overflow converting {cube.var_name}! Output data "
+               f"likely invalid. Use '--64' option to retain data integrity.")
+
         if _max > MAX_NP_INT32:
-            msg = f"Converting {cube.var_name} causes a 32 bit overflow!"
             warnings.warn(msg, category=RuntimeWarning)
 
         if _min < MIN_NP_INT32:
-            msg = f"Converting {cube.var_name} causes a 32 bit underflow!"
             warnings.warn(msg, category=RuntimeWarning)
 
         cube.data = cube.data.astype(np.int32)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -754,7 +754,8 @@ def convert_32_bit(cube):
         if _max > MAX_NP_INT32:
             msg = f"Converting {cube.var_name} causes a 32 bit overflow!"
             warnings.warn(msg, category=RuntimeWarning)
-        elif _min < MIN_NP_INT32:
+
+        if _min < MIN_NP_INT32:
             msg = f"Converting {cube.var_name} causes a 32 bit underflow!"
             warnings.warn(msg, category=RuntimeWarning)
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -159,6 +159,7 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
     except iris.exceptions.CoordinateNotFoundError:
         pass
 
+    # TODO: flag warnings as an error for the driver script?
     if not use64bit:
         convert_32_bit(cube)
 


### PR DESCRIPTION
Resolves #95.

This PR is mostly to extract & test 64 to 32 bit down-conversion from `cubewrite()`.

I've added a few things:
* New `data` member to `DummyCube`, so data grids can be attached to imitation cubes (it's simpler to reuse fixtures).
* Unit tests
* Added integer overflow warning (just in case)

I'll defer moving this step into `process()` until `cubewrite()` is deconstructed.

Comments welcome :-)