### PR TITLE
Refactor cube testing objects/mocking with `DummyCube`

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -997,16 +997,16 @@ def test_fix_level_coord_modify_cube_with_rho(level_coords_cube,
     # verify cube renaming with appropriate z_rho data
     cube = level_coords_cube
 
-    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name != "model_rho_level_number"
-    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name != "rho_level_height"
-    assert cube.coord(um2nc.SIGMA).var_name != "sigma_rho"
+    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name != um2nc.MODEL_RHO_LEVEL
+    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name != um2nc.RHO_LEVEL_HEIGHT
+    assert cube.coord(um2nc.SIGMA).var_name != um2nc.SIGMA_RHO
 
     rho = np.ones(z_sea_theta_data.shape) * level_heights[0]
     um2nc.fix_level_coord(cube, rho, z_sea_theta_data)
 
-    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name == "model_rho_level_number"
-    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name == "rho_level_height"
-    assert cube.coord(um2nc.SIGMA).var_name == "sigma_rho"
+    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name == um2nc.MODEL_RHO_LEVEL
+    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name == um2nc.RHO_LEVEL_HEIGHT
+    assert cube.coord(um2nc.SIGMA).var_name == um2nc.SIGMA_RHO
 
 
 def test_fix_level_coord_modify_cube_with_theta(level_heights,
@@ -1017,9 +1017,9 @@ def test_fix_level_coord_modify_cube_with_theta(level_heights,
     cube = level_coords_cube
     um2nc.fix_level_coord(cube, z_sea_rho_data, z_sea_theta_data)
 
-    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name == "model_theta_level_number"
-    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name == "theta_level_height"
-    assert cube.coord(um2nc.SIGMA).var_name == "sigma_theta"
+    assert cube.coord(um2nc.MODEL_LEVEL_NUM).var_name == um2nc.MODEL_THETA_LEVEL_NUM
+    assert cube.coord(um2nc.LEVEL_HEIGHT).var_name == um2nc.THETA_LEVEL_HEIGHT
+    assert cube.coord(um2nc.SIGMA).var_name == um2nc.SIGMA_THETA
 
 
 def test_fix_level_coord_skipped_if_no_levels(z_sea_rho_data, z_sea_theta_data):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -314,20 +314,6 @@ def test_stash_code_to_item_code_conversion():
     assert result == 30255
 
 
-@dataclass(frozen=True)
-class DummyStash:
-    """
-    Partial Stash representation for testing.
-    """
-    section: int
-    item: int
-
-
-def add_stash(cube, stash):
-    d = {um2nc.STASH: stash}
-    setattr(cube, "attributes", d)
-
-
 def test_set_item_codes():
     cube0 = DummyCube(1002, "d0", {um2nc.STASH: DummyStash(1, 2)})
     cube1 = DummyCube(3004, "d1", {um2nc.STASH: DummyStash(3, 4)})
@@ -341,6 +327,31 @@ def test_set_item_codes():
 
     assert c0.item_code == 1002
     assert c1.item_code == 3004
+
+
+def test_set_item_codes_avoid_overwrite():
+    item_code = 1007
+    item_code2 = 51006
+
+    cubes = [DummyCube(item_code, "fake_var"), DummyCube(item_code2, "fake_var2")]
+    um2nc.set_item_codes(cubes)
+    assert cubes[0].item_code == item_code
+    assert cubes[1].item_code == item_code2
+
+
+@dataclass(frozen=True)
+class DummyStash:
+    """
+    Partial Stash representation for testing.
+    """
+    section: int
+    item: int
+
+
+def add_stash(cube, stash):
+    d = {um2nc.STASH: stash}
+    setattr(cube, "attributes", d)
+
 
 
 class DummyCube:
@@ -375,16 +386,6 @@ class DummyCube:
         except KeyError:
             msg = f"{self.__class__}[{self.var_name}]: lacks coord for '{_name}'"
             raise CoordinateNotFoundError(msg)
-
-
-def test_set_item_codes_avoid_overwrite():
-    item_code = 1007
-    item_code2 = 51006
-
-    cubes = [DummyCube(item_code, "fake_var"), DummyCube(item_code2, "fake_var2")]
-    um2nc.set_item_codes(cubes)
-    assert cubes[0].item_code == item_code
-    assert cubes[1].item_code == item_code2
 
 
 @pytest.fixture

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -445,10 +445,8 @@ def test_cube_filtering_no_include_exclude(ua_plev_cube, heaviside_uv_cube):
 # cube variable renaming tests
 @pytest.fixture
 def x_wind_cube():
-    x_wind_cube = DummyCube(2, var_name="var_name",
-                            attributes={'STASH': DummyStash(0, 2)})
+    x_wind_cube = DummyCube(2, var_name="var_name")
     x_wind_cube.standard_name = "x_wind"
-    x_wind_cube.cell_methods = []
     return x_wind_cube
 
 
@@ -510,9 +508,8 @@ def test_fix_standard_name_update_x_wind(x_wind_cube):
 def test_fix_standard_name_update_y_wind():
     # test cube wind renaming block only
     # use empty std name to bypass renaming logic
-    m_cube = DummyCube(3, attributes={'STASH': DummyStash(0, 3)})
+    m_cube = DummyCube(3)
     m_cube.standard_name = "y_wind"
-    m_cube.cell_methods = []
 
     um2nc.fix_standard_name(m_cube, "", verbose=False)
     assert m_cube.standard_name == "northward_wind"

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -200,13 +200,6 @@ def test_process_mask_with_heaviside(air_temp_cube, precipitation_flux_cube,
         cubes = [air_temp_cube, precipitation_flux_cube, geo_potential_cube,
                  heaviside_uv_cube, heaviside_t_cube]
 
-        # TODO: convert heaviside cubes to NonCallableMagicMock like other fixtures?
-        for c in [heaviside_uv_cube, heaviside_t_cube]:
-            # add attrs to mimic real cubes
-            attrs = {um2nc.STASH: DummyStash(*um2nc.to_stash_code(c.item_code))}
-            c.attributes = attrs
-            c.cell_methods = []
-
         m_iris_load.return_value = cubes
         m_saver().__enter__ = mock.Mock(name="mock_sman")
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -113,6 +113,11 @@ class DummyCube:
             raise CoordinateNotFoundError(msg)
 
 
+# NB: these cube fixtures have been chosen to mimic cubes for testing key parts
+# of the process() workflow. Some cubes require pressure level masking with the
+# heaviside_uv/t cubes. These cubes facilitate different testing configurations.
+# Modifying them has the potential to reduce test coverage!
+
 @pytest.fixture
 def precipitation_flux_cube(lat_standard_nd_coord, lon_standard_nd_coord):
     # copied from aiihca.paa1jan.subset file
@@ -124,7 +129,7 @@ def precipitation_flux_cube(lat_standard_nd_coord, lon_standard_nd_coord):
 @pytest.fixture
 def geo_potential_cube(lat_v_nd_coord, lon_u_nd_coord):
     """Return new cube requiring heaviside_t masking"""
-    geo_potential = DummyCube(30207, "geopotential_height",
+    geo_potential = DummyCube(30297, "geopotential_height",
                               coords=[lat_v_nd_coord, lon_u_nd_coord])
     return geo_potential
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -87,6 +87,29 @@ def geo_potential_cube(lat_v_nd_coord, lon_u_nd_coord):
 
 
 @pytest.fixture
+def ua_plev_cube():
+    return DummyCube(30201, "ua_plev")
+
+
+@pytest.fixture
+def heaviside_uv_cube(lat_v_nd_coord, lon_u_nd_coord):
+    return DummyCube(30301, "heaviside_uv",
+                     coords=[lat_v_nd_coord, lon_u_nd_coord])
+
+
+@pytest.fixture
+def ta_plev_cube(lat_v_nd_coord, lon_u_nd_coord):
+    return DummyCube(30204, "ta_plev",
+                     coords=[lat_v_nd_coord, lon_u_nd_coord])
+
+
+@pytest.fixture
+def heaviside_t_cube(lat_standard_eg_coord, lon_standard_eg_coord):
+    return DummyCube(30304, "heaviside_t",
+                     coords=[lat_standard_eg_coord, lon_standard_eg_coord])
+
+
+@pytest.fixture
 def std_args():
     # TODO: make args namedtuple?
     args = mock.Mock()
@@ -377,29 +400,6 @@ class DummyCube:
         except KeyError:
             msg = f"{self.__class__}[{self.var_name}]: lacks coord for '{_name}'"
             raise CoordinateNotFoundError(msg)
-
-
-@pytest.fixture
-def ua_plev_cube():
-    return DummyCube(30201, "ua_plev")
-
-
-@pytest.fixture
-def heaviside_uv_cube(lat_v_nd_coord, lon_u_nd_coord):
-    return DummyCube(30301, "heaviside_uv",
-                     coords=[lat_v_nd_coord, lon_u_nd_coord])
-
-
-@pytest.fixture
-def ta_plev_cube(lat_v_nd_coord, lon_u_nd_coord):
-    return DummyCube(30204, "ta_plev",
-                     coords=[lat_v_nd_coord, lon_u_nd_coord])
-
-
-@pytest.fixture
-def heaviside_t_cube(lat_standard_eg_coord, lon_standard_eg_coord):
-    return DummyCube(30304, "heaviside_t",
-                     coords=[lat_standard_eg_coord, lon_standard_eg_coord])
 
 
 # cube filtering tests

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -79,18 +79,18 @@ def air_temp_cube(lat_river_coord, lon_river_coord):
 
 
 @pytest.fixture
-def precipitation_flux_cube(lat_river_coord, lon_river_coord):
+def precipitation_flux_cube(lat_standard_nd_coord, lon_standard_nd_coord):
     # copied from aiihca.paa1jan.subset file
     precipitation_flux = DummyCube(5216, "precipitation_flux",
-                                   coords=[lat_river_coord, lon_river_coord])
+                                   coords=[lat_standard_nd_coord, lon_standard_nd_coord])
     return precipitation_flux
 
 
 @pytest.fixture
-def geo_potential_cube(lat_river_coord, lon_river_coord):
+def geo_potential_cube(lat_v_nd_coord, lon_u_nd_coord):
     """Return new cube requiring heaviside_t masking"""
-    geo_potential = DummyCube(30297, "geopotential_height",
-                              coords=[lat_river_coord, lon_river_coord])
+    geo_potential = DummyCube(30207, "geopotential_height",
+                              coords=[lat_v_nd_coord, lon_u_nd_coord])
     return geo_potential
 
 
@@ -394,21 +394,21 @@ def ua_plev_cube():
 
 
 @pytest.fixture
-def heaviside_uv_cube(lat_river_coord, lon_river_coord):
+def heaviside_uv_cube(lat_v_nd_coord, lon_u_nd_coord):
     return DummyCube(30301, "heaviside_uv",
-                     coords=[lat_river_coord, lon_river_coord])
+                     coords=[lat_v_nd_coord, lon_u_nd_coord])
 
 
 @pytest.fixture
-def ta_plev_cube(lat_river_coord, lon_river_coord):
-    return DummyCube(30294, "ta_plev",
-                     coords=[lat_river_coord, lon_river_coord])
+def ta_plev_cube(lat_v_nd_coord, lon_u_nd_coord):
+    return DummyCube(30204, "ta_plev",
+                     coords=[lat_v_nd_coord, lon_u_nd_coord])
 
 
 @pytest.fixture
-def heaviside_t_cube(lat_river_coord, lon_river_coord):
+def heaviside_t_cube(lat_standard_eg_coord, lon_standard_eg_coord):
     return DummyCube(30304, "heaviside_t",
-                     coords=[lat_river_coord, lon_river_coord])
+                     coords=[lat_standard_eg_coord, lon_standard_eg_coord])
 
 
 # cube filtering tests

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -86,9 +86,9 @@ def precipitation_flux_cube(lat_river_coord, lon_river_coord):
     return precipitation_flux
 
 
-# create cube requiring heaviside_t masking
 @pytest.fixture
 def geo_potential_cube(lat_river_coord, lon_river_coord):
+    """Return new cube requiring heaviside_t masking"""
     geo_potential = DummyCube(30297, "geopotential_height",
                               coords=[lat_river_coord, lon_river_coord])
     return geo_potential
@@ -120,15 +120,15 @@ def fake_out_path():
     return "/tmp-does-not-exist/fake_input_fields_file.nc"
 
 
+# FIXME: the convoluted setup in test_process_...() is a code smell
+#        use the following tests to gradually refactor process()
+# TODO: evolve towards design where input & output file I/O is extracted from
+#       process() & the function only takes *raw data only* (is highly testable)
+
 def test_process_no_heaviside_drop_cubes(air_temp_cube, precipitation_flux_cube,
                                          geo_potential_cube, mule_vars, std_args,
                                          fake_in_path, fake_out_path):
     """Attempt end-to-end process() test, dropping cubes requiring masking."""
-
-    # FIXME: this convoluted setup is a code smell
-    #        use these tests to gradually refactor process()
-    # TODO: move towards a design where input & output I/O is extracted from process()
-    #       process() should eventually operate on *data only* args
     with (
         # use mocks to prevent mule data extraction file I/O
         mock.patch("mule.load_umfile"),
@@ -367,8 +367,8 @@ class DummyCube:
         self.cell_methods = []
         self.data = None
 
-        # Mimic a coordinate dictionary keys for iris coordinate names. This
-        # ensures the access key for coord() matches the coordinate's name
+        # Mimic a coordinate dictionary with iris coordinate names as keys to
+        # ensure the coord() access key matches the coordinate's name
         self._coordinates = {c.name(): c for c in coords} if coords else {}
 
         section, item = um2nc.to_stash_code(item_code)
@@ -419,7 +419,7 @@ def heaviside_t_cube(lat_river_coord, lon_river_coord):
 
 
 # cube filtering tests
-# use wrap results in tuples to capture generator output in sequence
+# NB: wrap results in tuples to capture generator output in sequences
 
 def test_cube_filtering_mutually_exclusive(ua_plev_cube, heaviside_uv_cube):
     include = [30201]
@@ -992,6 +992,7 @@ def level_coords(level_heights):
             um2nc.SIGMA: iris.coords.AuxCoord(np.array([0.99771646]))}
 
 
+# TODO: replace this with a DummyCube
 @pytest.fixture
 def get_fake_cube_coords(level_coords):
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -127,10 +127,10 @@ def precipitation_flux_cube(lat_standard_nd_coord, lon_standard_nd_coord):
 
 
 @pytest.fixture
-def geo_potential_cube(lat_v_nd_coord, lon_u_nd_coord):
+def geo_potential_cube(lat_standard_eg_coord, lon_standard_eg_coord):
     """Return new cube requiring heaviside_t masking"""
     geo_potential = DummyCube(30297, "geopotential_height",
-                              coords=[lat_v_nd_coord, lon_u_nd_coord])
+                              coords=[lat_standard_eg_coord, lon_standard_eg_coord])
     return geo_potential
 
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -123,8 +123,7 @@ def fake_out_path():
 # FIXME: the convoluted setup in test_process_...() is a code smell
 #        use the following tests to gradually refactor process()
 # TODO: evolve towards design where input & output file I/O is extracted from
-#       process() & the function only takes *raw data only* (is highly testable)
-
+#       process() & the function takes *raw data only* (is highly testable)
 def test_process_no_heaviside_drop_cubes(air_temp_cube, precipitation_flux_cube,
                                          geo_potential_cube, mule_vars, std_args,
                                          fake_in_path, fake_out_path):
@@ -446,7 +445,7 @@ def test_cube_filtering_no_include_exclude(ua_plev_cube, heaviside_uv_cube):
 @pytest.fixture
 def x_wind_cube():
     x_wind_cube = DummyCube(2, var_name="var_name",
-                          attributes={'STASH': DummyStash(0, 2)})
+                            attributes={'STASH': DummyStash(0, 2)})
     x_wind_cube.standard_name = "x_wind"
     x_wind_cube.cell_methods = []
     return x_wind_cube
@@ -980,6 +979,7 @@ def level_heights():
 
 @pytest.fixture
 def level_coords(level_heights):
+    # data likely extracted from aiihca.subset
     return [iris.coords.DimCoord(range(1, 39), var_name=um2nc.MODEL_LEVEL_NUM),
             iris.coords.DimCoord(level_heights, var_name=um2nc.LEVEL_HEIGHT),
             iris.coords.AuxCoord(np.array([0.99771646]), var_name=um2nc.SIGMA)]

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -67,8 +67,16 @@ NC_FORMATS = {
 }
 
 MODEL_LEVEL_NUM = "model_level_number"
+MODEL_RHO_LEVEL = "model_rho_level_number"
+MODEL_THETA_LEVEL_NUM = "model_theta_level_number"
+
 LEVEL_HEIGHT = "level_height"
+THETA_LEVEL_HEIGHT = "theta_level_height"
+RHO_LEVEL_HEIGHT = "rho_level_height"
+
 SIGMA = "sigma"
+SIGMA_THETA = "sigma_theta"
+SIGMA_RHO = "sigma_rho"
 
 
 class PostProcessingError(Exception):


### PR DESCRIPTION
This closes #69.

This PR covers multiple elements to switch tests to using `DummyCube`:
* Replaces several `Mock` objs masquerading as cubes with `DummyCube`
* Removes old setup cruft
* Cleans some test fixtures
* Adds coords to other test fixtures (fixtures better open for reuse)
* Removes `mock.patch("umpost.um2netcdf.fix_latlon_coords")` in `process()` tests
* BONUS: removes `mock.patch("umpost.um2netcdf.fix_level_coord")` in `process()` tests

Any comments welcome!