### PR TITLE
Extract forecast reference time

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -82,6 +82,7 @@ class DummyStash:
     item: int
 
 
+# TODO: would making this a dataclass provide any benefit?
 class DummyCube:
     """
     Imitation iris Cube for unit testing.
@@ -119,13 +120,19 @@ class DummyCube:
             msg = f"{self.__class__}[{self.var_name}]: lacks coord for '{_name}'"
             raise CoordinateNotFoundError(msg)
 
-    def update_coords(self, coords):
+    def remove_coord(self, coord):
+        del self._coordinates[coord]
+
+    # Auxiliary methods
+    # These methods DO NOT exist in the iris cube API, these are helper methods
+    # to configure DummyCubes for testing.
+    #
+    # All methods should see an `aux_` prefix
+
+    def aux_update_coords(self, coords):
         # Mimic a coordinate dictionary keys for iris coordinate names. This
         # ensures the access key for coord() matches the coordinate's name
         self._coordinates = {c.name(): c for c in coords} if coords else {}
-
-    def remove_coord(self, coord):
-        del self._coordinates[coord]
 
 
 # NB: these cube fixtures have been chosen to mimic cubes for testing key parts
@@ -1178,7 +1185,7 @@ def test_fix_forecast_reference_time_exit_on_missing_ref_time(forecast_cube):
 def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
                                                           forecast_ref_time_coord):
     # verify fix_forecast_ref_time() exits early if the coord is missing
-    forecast_cube.update_coords([forecast_ref_time_coord])
+    forecast_cube.aux_update_coords([forecast_ref_time_coord])
 
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         forecast_cube.coord(um2nc.TIME)
@@ -1196,9 +1203,9 @@ def test_fix_forecast_reference_time_standard(forecast_cube,
     forecast_period = iris.coords.DimCoord([372.0],
                                            standard_name=um2nc.FORECAST_PERIOD)
 
-    forecast_cube.update_coords([forecast_ref_time_coord,
-                                 time_coord,
-                                 forecast_period])
+    forecast_cube.aux_update_coords([forecast_ref_time_coord,
+                                     time_coord,
+                                     forecast_period])
 
     assert um2nc.fix_forecast_reference_time(forecast_cube) is None
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1182,3 +1182,34 @@ def test_convert_32_bit_with_float64(ua_plev_cube):
     ua_plev_cube.data = array
     um2nc.convert_32_bit(ua_plev_cube)
     assert ua_plev_cube.data.dtype == np.float32
+
+
+# fix forecast reference time tests
+@pytest.fixture
+def forecast_cube():
+    return DummyCube(item_code=999)
+
+
+@pytest.fixture
+def forecast_ref_time_coord():
+    # data ripped from aiihca data file
+    ref_time = iris.coords.DimCoord([-16383336.],
+                                    standard_name=um2nc.FORECAST_REFERENCE_TIME)
+    return ref_time
+
+
+def test_fix_forecast_reference_time_exit_on_missing_ref_time(forecast_cube):
+    with pytest.raises(iris.exceptions.CoordinateNotFoundError):
+        forecast_cube.coord(um2nc.FORECAST_REFERENCE_TIME)
+
+    um2nc.fix_forecast_reference_time(forecast_cube)
+
+
+def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
+                                                          forecast_ref_time_coord):
+    forecast_cube.update_coords([forecast_ref_time_coord])
+
+    with pytest.raises(iris.exceptions.CoordinateNotFoundError):
+        forecast_cube.coord(um2nc.TIME)
+
+    um2nc.fix_forecast_reference_time(forecast_cube)

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -406,10 +406,10 @@ class DummyCube:
         self.standard_name = None
         self.long_name = None
         self.data = None
+        self._coordinates = {}
 
-        # Mimic a coordinate dictionary keys for iris coordinate names. This
-        # ensures the access key for coord() matches the coordinate's name
-        self._coordinates = {c.name(): c for c in coords} if coords else {}
+        if coords:
+            self.update_coords(coords)
 
     def name(self):
         return self.var_name
@@ -420,6 +420,11 @@ class DummyCube:
         except KeyError:
             msg = f"{self.__class__}: lacks coord for '{name}'"
             raise CoordinateNotFoundError(msg)
+
+    def update_coords(self, coords):
+        # Mimic a coordinate dictionary keys for iris coordinate names. This
+        # ensures the access key for coord() matches the coordinate's name
+        self._coordinates = {c.name(): c for c in coords} if coords else {}
 
 
 def test_set_item_codes_avoid_overwrite():

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1192,28 +1192,38 @@ def test_convert_32_bit_with_float64(ua_plev_cube):
 # fix forecast reference time tests
 @pytest.fixture
 def forecast_cube():
+    # NB: using a non-existent item code for fake forecast cube
     return DummyCube(item_code=999)
 
 
 @pytest.fixture
-def forecast_ref_time_coord():
-    # units data ripped from aiihca data file
+def time_points():
+    """Use for cube.coord('time').points attribute."""
+    return [-16382964.]
+
+
+@pytest.fixture
+def forecast_ref_time_coord(time_points):
+    # units & point data ripped from aiihca.paa1jan data file:
+    # cubes = iris.load("aiihca.paa1jan")
+    # cubes[0].long_name --> 'atmosphere_optical_thickness_due_to_sulphate_ambient_aerosol'
+    # cubes[0].coord("time").points --> array([-16382964.])
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00")
     assert unit.calendar == um2nc.STANDARD
 
-    return iris.coords.DimCoord([-16383336.],
+    return iris.coords.DimCoord(time_points,
                                 standard_name=um2nc.FORECAST_REFERENCE_TIME,
                                 units=unit)
 
 
 @pytest.fixture
-def time_coord():
+def time_coord(time_points):
     # units data ripped from aiihca data file
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00",
                          calendar=um2nc.GREGORIAN)
     assert unit.calendar == um2nc.STANDARD
 
-    return iris.coords.DimCoord([-16382964.],
+    return iris.coords.DimCoord(time_points,
                                 standard_name=um2nc.TIME,
                                 units=unit)
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1209,7 +1209,7 @@ def forecast_ref_time_coord(time_points):
     # cubes[0].long_name --> 'atmosphere_optical_thickness_due_to_sulphate_ambient_aerosol'
     # cubes[0].coord("time").points --> array([-16382964.])
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00")
-    assert unit.calendar == um2nc.STANDARD
+    assert unit.calendar == cf_units.CALENDAR_STANDARD
 
     return iris.coords.DimCoord(time_points,
                                 standard_name=um2nc.FORECAST_REFERENCE_TIME,
@@ -1220,8 +1220,8 @@ def forecast_ref_time_coord(time_points):
 def time_coord(time_points):
     # units data ripped from aiihca data file
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00",
-                         calendar=um2nc.GREGORIAN)
-    assert unit.calendar == um2nc.STANDARD
+                         calendar=cf_units.CALENDAR_GREGORIAN)
+    assert unit.calendar == cf_units.CALENDAR_STANDARD
 
     return iris.coords.DimCoord(time_points,
                                 standard_name=um2nc.TIME,

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1134,7 +1134,13 @@ def time_points():
 
 
 @pytest.fixture
-def forecast_ref_time_coord(time_points):
+def forecast_ref_time_points():
+    """Use for cube.coord('forecast_reference_time').points attribute."""
+    return [-16383336.]
+
+
+@pytest.fixture
+def forecast_ref_time_coord(forecast_ref_time_points):
     # units & point data ripped from aiihca.paa1jan data file:
     # cubes = iris.load("aiihca.paa1jan")
     # cubes[0].long_name --> 'atmosphere_optical_thickness_due_to_sulphate_ambient_aerosol'
@@ -1142,7 +1148,7 @@ def forecast_ref_time_coord(time_points):
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00")
     assert unit.calendar == cf_units.CALENDAR_STANDARD
 
-    return iris.coords.DimCoord(time_points,
+    return iris.coords.DimCoord(forecast_ref_time_points,
                                 standard_name=um2nc.FORECAST_REFERENCE_TIME,
                                 units=unit)
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -428,6 +428,9 @@ class DummyCube:
         # ensures the access key for coord() matches the coordinate's name
         self._coordinates = {c.name(): c for c in coords} if coords else {}
 
+    def remove_coord(self, coord):
+        del self._coordinates[coord]
+
 
 def test_set_item_codes_avoid_overwrite():
     item_code = 1007
@@ -1230,3 +1233,33 @@ def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
         forecast_cube.coord(um2nc.TIME)
 
     assert um2nc.fix_forecast_reference_time(forecast_cube) is None
+
+
+def test_fix_forecast_reference_time_standard(forecast_cube,
+                                              forecast_ref_time_coord,
+                                              time_coord):
+
+    forecast_period = iris.coords.DimCoord([372.0],
+                                           standard_name=um2nc.FORECAST_PERIOD)
+
+    forecast_cube.update_coords([forecast_ref_time_coord,
+                                 time_coord,
+                                 forecast_period])
+
+    assert um2nc.fix_forecast_reference_time(forecast_cube) is None
+
+
+@pytest.mark.skip
+def test_fix_forecast_reference_time_gregorian(forecast_cube,
+                                               forecast_ref_time_coord,
+                                               time_coord):
+    msg = "Is time.units.calendar == 'gregorian' branch & testing required?"
+    raise NotImplementedError(msg)
+
+
+@pytest.mark.skip
+def test_fix_forecast_reference_time_proleptic_gregorian(forecast_cube,
+                                                         forecast_ref_time_coord,
+                                                         time_coord):
+    msg = "Is time.units.calendar == 'proleptic_gregorian' branch & testing required?"
+    raise NotImplementedError(msg)

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1146,6 +1146,8 @@ def forecast_ref_time_points():
     return [-16383336.]
 
 
+# FIXME: unit.calendar needs updating as per:
+#  https://github.com/ACCESS-NRI/um2nc-standalone/pull/118#issuecomment-2404034473
 @pytest.fixture
 def forecast_ref_time_coord(forecast_ref_time_points):
     # units & point data ripped from aiihca.paa1jan data file:
@@ -1160,6 +1162,8 @@ def forecast_ref_time_coord(forecast_ref_time_points):
                                 units=unit)
 
 
+# FIXME: unit.calendar needs updating as per:
+#  https://github.com/ACCESS-NRI/um2nc-standalone/pull/118#issuecomment-2404034473
 @pytest.fixture
 def time_coord(time_points):
     # units data ripped from aiihca data file

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1,6 +1,8 @@
 import unittest.mock as mock
 from dataclasses import dataclass
 from collections import namedtuple
+
+import cf_units
 from iris.exceptions import CoordinateNotFoundError
 import operator
 
@@ -1192,10 +1194,25 @@ def forecast_cube():
 
 @pytest.fixture
 def forecast_ref_time_coord():
-    # data ripped from aiihca data file
-    ref_time = iris.coords.DimCoord([-16383336.],
-                                    standard_name=um2nc.FORECAST_REFERENCE_TIME)
-    return ref_time
+    # units data ripped from aiihca data file
+    unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00")
+    assert unit.calendar == "standard"
+
+    return iris.coords.DimCoord([-16383336.],
+                                standard_name=um2nc.FORECAST_REFERENCE_TIME,
+                                units=unit)
+
+
+@pytest.fixture
+def time_coord():
+    # units data ripped from aiihca data file
+    unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00",
+                         calendar=um2nc.GREGORIAN)
+    assert unit.calendar == "standard"
+
+    return iris.coords.DimCoord([-16382964.],
+                                standard_name=um2nc.TIME,
+                                units=unit)
 
 
 def test_fix_forecast_reference_time_exit_on_missing_ref_time(forecast_cube):

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1,4 +1,5 @@
 import unittest.mock as mock
+import warnings
 from dataclasses import dataclass
 from collections import namedtuple
 
@@ -1159,26 +1160,33 @@ def time_coord(time_points):
 
 
 def test_fix_forecast_reference_time_exit_on_missing_ref_time(forecast_cube):
+    # verify fix_forecast_ref_time() exits early if the coord is missing
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         forecast_cube.coord(um2nc.FORECAST_REFERENCE_TIME)
 
+    # TODO: fails to assert the cube is unmodified
+    # TODO: is this test even needed?
     assert um2nc.fix_forecast_reference_time(forecast_cube) is None
 
 
 def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
                                                           forecast_ref_time_coord):
+    # verify fix_forecast_ref_time() exits early if the coord is missing
     forecast_cube.update_coords([forecast_ref_time_coord])
 
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         forecast_cube.coord(um2nc.TIME)
 
+    # TODO: fails to assert the cube is unmodified
+    # TODO: is this test even needed?
     assert um2nc.fix_forecast_reference_time(forecast_cube) is None
 
 
 def test_fix_forecast_reference_time_standard(forecast_cube,
                                               forecast_ref_time_coord,
                                               time_coord):
-
+    # TODO: executes part of the ref time fix code
+    # TODO: needs to assert the changes!
     forecast_period = iris.coords.DimCoord([372.0],
                                            standard_name=um2nc.FORECAST_PERIOD)
 
@@ -1187,6 +1195,9 @@ def test_fix_forecast_reference_time_standard(forecast_cube,
                                  forecast_period])
 
     assert um2nc.fix_forecast_reference_time(forecast_cube) is None
+
+    # TODO: add assertions here
+    warnings.warn("test_fix_forecast_reference_time_standard asserts nothing")
 
 
 @pytest.mark.skip

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1202,7 +1202,7 @@ def test_fix_forecast_reference_time_exit_on_missing_ref_time(forecast_cube):
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         forecast_cube.coord(um2nc.FORECAST_REFERENCE_TIME)
 
-    um2nc.fix_forecast_reference_time(forecast_cube)
+    assert um2nc.fix_forecast_reference_time(forecast_cube) is None
 
 
 def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
@@ -1212,4 +1212,4 @@ def test_fix_forecast_reference_time_exit_on_missing_time(forecast_cube,
     with pytest.raises(iris.exceptions.CoordinateNotFoundError):
         forecast_cube.coord(um2nc.TIME)
 
-    um2nc.fix_forecast_reference_time(forecast_cube)
+    assert um2nc.fix_forecast_reference_time(forecast_cube) is None

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1196,7 +1196,7 @@ def forecast_cube():
 def forecast_ref_time_coord():
     # units data ripped from aiihca data file
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00")
-    assert unit.calendar == "standard"
+    assert unit.calendar == um2nc.STANDARD
 
     return iris.coords.DimCoord([-16383336.],
                                 standard_name=um2nc.FORECAST_REFERENCE_TIME,
@@ -1208,7 +1208,7 @@ def time_coord():
     # units data ripped from aiihca data file
     unit = cf_units.Unit(unit="hours since 1970-01-01 00:00:00",
                          calendar=um2nc.GREGORIAN)
-    assert unit.calendar == "standard"
+    assert unit.calendar == um2nc.STANDARD
 
     return iris.coords.DimCoord([-16382964.],
                                 standard_name=um2nc.TIME,

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -76,6 +76,7 @@ TIME = "time"
 PROLEPTIC_GREGORIAN = "proleptic_gregorian"
 GREGORIAN = "gregorian"
 FORECAST_PERIOD = "forecast_period"
+STANDARD = "standard"
 
 
 class PostProcessingError(Exception):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -73,6 +73,9 @@ SIGMA = "sigma"
 # forecast reference time constants
 FORECAST_REFERENCE_TIME = "forecast_reference_time"
 TIME = "time"
+PROLEPTIC_GREGORIAN = "proleptic_gregorian"
+GREGORIAN = "gregorian"
+FORECAST_PERIOD = "forecast_period"
 
 
 class PostProcessingError(Exception):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -368,6 +368,9 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
 def fix_forecast_reference_time(cube):
     # If reference date is before 1600 use proleptic gregorian
     # calendar and change units from hours to days
+
+    # TODO: constrain the exception handler to the first 2 coord lookups?
+    # TODO: detect dump files & exit early (look up all coords early)
     try:
         reftime = cube.coord(FORECAST_REFERENCE_TIME)
         time = cube.coord(TIME)
@@ -388,6 +391,12 @@ def fix_forecast_reference_time(cube):
             if time.bounds is not None:
                 time.bounds = time.bounds / 24.
 
+        # TODO: remove_coord() calls the coord() lookup, which raises
+        #       CoordinateNotFoundError if the forecast period is missing, this
+        #       ties remove_coords() to the exception handler below
+        #
+        # TODO: if removing the forecast period fails, forecast reference time is
+        #       NOT removed. What is the desired behaviour?
         cube.remove_coord(FORECAST_PERIOD)
         cube.remove_coord(FORECAST_REFERENCE_TIME)
     except iris.exceptions.CoordinateNotFoundError:

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -361,16 +361,16 @@ def fix_forecast_reference_time(cube):
     # If reference date is before 1600 use proleptic gregorian
     # calendar and change units from hours to days
     try:
-        reftime = cube.coord('forecast_reference_time')
-        time = cube.coord('time')
+        reftime = cube.coord(FORECAST_REFERENCE_TIME)
+        time = cube.coord(TIME)
         refdate = reftime.units.num2date(reftime.points[0])
         assert time.units.origin == 'hours since 1970-01-01 00:00:00'
 
-        if time.units.calendar == 'proleptic_gregorian' and refdate.year < 1600:
+        if time.units.calendar == cf_units.CALENDAR_PROLEPTIC_GREGORIAN and refdate.year < 1600:
             convert_proleptic(time)
         else:
-            if time.units.calendar == 'gregorian':
-                new_calendar = 'proleptic_gregorian'
+            if time.units.calendar == cf_units.CALENDAR_GREGORIAN:
+                new_calendar = cf_units.CALENDAR_PROLEPTIC_GREGORIAN
             else:
                 new_calendar = time.units.calendar
 
@@ -380,8 +380,8 @@ def fix_forecast_reference_time(cube):
             if time.bounds is not None:
                 time.bounds = time.bounds / 24.
 
-        cube.remove_coord('forecast_period')
-        cube.remove_coord('forecast_reference_time')
+        cube.remove_coord(FORECAST_PERIOD)
+        cube.remove_coord(FORECAST_REFERENCE_TIME)
     except iris.exceptions.CoordinateNotFoundError:
         # Dump files don't have forecast_reference_time
         pass
@@ -390,7 +390,8 @@ def fix_forecast_reference_time(cube):
 # TODO: rename time to avoid clash with builtin time module
 def convert_proleptic(time):
     # Convert units from hours to days and shift origin from 1970 to 0001
-    newunits = cf_units.Unit("days since 0001-01-01 00:00", calendar='proleptic_gregorian')
+    newunits = cf_units.Unit("days since 0001-01-01 00:00",
+                             calendar=cf_units.CALENDAR_PROLEPTIC_GREGORIAN)
     tvals = np.array(time.points)  # Need a copy because can't assign to time.points[i]
     tbnds = np.array(time.bounds) if time.bounds is not None else None
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -106,34 +106,6 @@ def pg_calendar(self):
 PPField.calendar = pg_calendar
 
 
-# TODO: rename time to avoid clash with builtin time module
-def convert_proleptic(time):
-    # Convert units from hours to days and shift origin from 1970 to 0001
-    newunits = cf_units.Unit("days since 0001-01-01 00:00", calendar='proleptic_gregorian')
-    tvals = np.array(time.points)  # Need a copy because can't assign to time.points[i]
-    tbnds = np.array(time.bounds) if time.bounds is not None else None
-
-    for i in range(len(time.points)):
-        date = time.units.num2date(tvals[i])
-        newdate = cftime.DatetimeProlepticGregorian(date.year, date.month, date.day,
-                                                    date.hour, date.minute, date.second)
-        tvals[i] = newunits.date2num(newdate)
-
-        if tbnds is not None:  # Fields with instantaneous data don't have bounds
-            for j in range(2):
-                date = time.units.num2date(tbnds[i][j])
-                newdate = cftime.DatetimeProlepticGregorian(date.year, date.month, date.day,
-                                                            date.hour, date.minute, date.second)
-                tbnds[i][j] = newunits.date2num(newdate)
-
-    time.points = tvals
-
-    if tbnds is not None:
-        time.bounds = tbnds
-
-    time.units = newunits
-
-
 def fix_lat_coord_name(lat_coordinate, grid_type, dlat):
     """
     Add a 'var_name' attribute to a latitude coordinate object
@@ -412,6 +384,34 @@ def fix_forecast_reference_time(cube):
     except iris.exceptions.CoordinateNotFoundError:
         # Dump files don't have forecast_reference_time
         pass
+
+
+# TODO: rename time to avoid clash with builtin time module
+def convert_proleptic(time):
+    # Convert units from hours to days and shift origin from 1970 to 0001
+    newunits = cf_units.Unit("days since 0001-01-01 00:00", calendar='proleptic_gregorian')
+    tvals = np.array(time.points)  # Need a copy because can't assign to time.points[i]
+    tbnds = np.array(time.bounds) if time.bounds is not None else None
+
+    for i in range(len(time.points)):
+        date = time.units.num2date(tvals[i])
+        newdate = cftime.DatetimeProlepticGregorian(date.year, date.month, date.day,
+                                                    date.hour, date.minute, date.second)
+        tvals[i] = newunits.date2num(newdate)
+
+        if tbnds is not None:  # Fields with instantaneous data don't have bounds
+            for j in range(2):
+                date = time.units.num2date(tbnds[i][j])
+                newdate = cftime.DatetimeProlepticGregorian(date.year, date.month, date.day,
+                                                            date.hour, date.minute, date.second)
+                tbnds[i][j] = newunits.date2num(newdate)
+
+    time.points = tvals
+
+    if tbnds is not None:
+        time.bounds = tbnds
+
+    time.units = newunits
 
 
 def fix_cell_methods(cell_methods):

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -70,6 +70,10 @@ MODEL_LEVEL_NUM = "model_level_number"
 LEVEL_HEIGHT = "level_height"
 SIGMA = "sigma"
 
+# forecast reference time constants
+FORECAST_REFERENCE_TIME = "forecast_reference_time"
+TIME = "time"
+
 
 class PostProcessingError(Exception):
     """Generic class for um2nc specific errors."""

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -72,11 +72,8 @@ SIGMA = "sigma"
 
 # forecast reference time constants
 FORECAST_REFERENCE_TIME = "forecast_reference_time"
-TIME = "time"
-PROLEPTIC_GREGORIAN = "proleptic_gregorian"
-GREGORIAN = "gregorian"
 FORECAST_PERIOD = "forecast_period"
-STANDARD = "standard"
+TIME = "time"
 
 
 class PostProcessingError(Exception):


### PR DESCRIPTION
First step to doing #100.

This PR is intended for facilitating testing functionality for fixing the forecast reference time.

As of late Sept 2024, work up to commit fd664c7b only provides a skeleton of unit tests. It doesn't meaningfully test any cube time changes. This PR includes some skipped tests as the testing required is unclear.

Work on this PR needs to answer & address the following:
* [ ] Is the `time.units.calendar == 'gregorian'` code branch & testing required?
* [ ] Is the `time.units.calendar == 'proleptic_gregorian'` code branch & testing required?
* [ ] What inputs should be tested?
* [ ] What outputs should be tested?
* [ ] What cube state/attrs should be tested?
* [ ] Is the code branch covered by `test_fix_forecast_reference_time_standard()` required?

These questions will help determine what work is required. Any comments/ideas welcome!

Fixing & testing this function is specified in #141.