### PR TITLE
Prevent mule missing STASHmaster warnings

### DIFF
--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -465,7 +465,14 @@ def apply_mask(c, heaviside, hcrit):
 
 
 def process(infile, outfile, args):
-    ff = mule.load_umfile(str(infile))
+
+    with warnings.catch_warnings():
+        # NB: Information from STASHmaster file is not required by `process`.
+        # Hence supress missing STASHmaster warnings.
+        warnings.filterwarnings(action="ignore", category=UserWarning,
+                                message=r"\sUnable to load STASHmaster")
+        ff = mule.load_umfile(str(infile))
+
     mv = process_mule_vars(ff)
 
     cubes = iris.load(infile)


### PR DESCRIPTION
Closes #126 

This PR adds a warning filter around the `mule.load_umfile()` call in `process`, in order to hide warnings about missing STASHmaster files. The information in these files is not used in `um2nc` and hence these warnings aren't too relevant.

I aded the filter directly in `process` to try and keep it localised, however this does add slightly more code to `process`. Any suggested changes or ideas are welcome!