### PR TITLE
Capture 32 bit overflow warnings in tests.

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1084,6 +1084,9 @@ def test_convert_32_bit_safe(ua_plev_cube):
                           ([-3000000000], operator.lt, np.iinfo(np.int32).min)])
 def test_convert_32_bit_overflow_warning(ua_plev_cube, array, _operator, bound):
     # ensure overflow covered for large positive & negative int64s
+    msg = f"Over/underflow impossible with {array[0]} {_operator} {bound}"
+    assert _operator(array[0], bound), msg
+
     ua_plev_cube.data = np.array(array, dtype=np.int64)
 
     with pytest.warns(RuntimeWarning) as record:
@@ -1092,9 +1095,6 @@ def test_convert_32_bit_overflow_warning(ua_plev_cube, array, _operator, bound):
         if not record:
             msg = f"No overflow warning with {array} {_operator} {bound}"
             pytest.fail(msg)
-
-    if _operator:
-        assert _operator(array[0], bound)
 
     assert ua_plev_cube.data.dtype == np.int32
 

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -1069,6 +1069,15 @@ def test_fix_pressure_levels_reverse_pressure():
 
 # int64 to int32 data conversion tests
 # NB: skip float64 to float32 overflow as float32 min/max is huge: -/+ 3.40e+38
+
+def test_convert_32_bit_safe(ua_plev_cube):
+    data = [1e6, 200, 100, 10, 1, 0, -10]
+    ua_plev_cube.data = np.array(data, dtype=np.int64)
+    um2nc.convert_32_bit(ua_plev_cube)
+    assert ua_plev_cube.data.dtype == np.int32
+    assert np.all(ua_plev_cube.data == data)
+
+
 @pytest.mark.parametrize("array,_operator,bound",
                          [([3000000000], operator.gt, np.iinfo(np.int32).max),
                           ([-3000000000], operator.lt, np.iinfo(np.int32).min)])


### PR DESCRIPTION
Closes #128.

This PR covers a few things:
* Decouples the simple int conversion case from the parameter generated overflow testing
* Moves the basic condition to its own test
* Captures overflow warnings to keep test output clean

Any comments welcome!