### PR TITLE
Capture & test cube dropping warnings in `test_process()`

### DIFF
--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -217,7 +217,9 @@ def test_process_no_heaviside_drop_cubes(ta_plev_cube, precipitation_flux_cube,
         assert precipitation_flux_cube.data is None
 
         # air temp & geo potential should be dropped in process()
-        processed = um2nc.process(fake_in_path, fake_out_path, std_args)
+        with pytest.warns(RuntimeWarning):
+            processed = um2nc.process(fake_in_path, fake_out_path, std_args)
+
         assert len(processed) == 1
         cube = processed[0]
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -738,12 +738,14 @@ def non_masking_cubes(cubes, heaviside_uv, heaviside_t, verbose: bool):
     for c in cubes:
         if require_heaviside_uv(c.item_code) and heaviside_uv is None:
             if verbose:
-                warnings.warn(msg.format("heaviside_uv", c.name()))
+                warnings.warn(msg.format("heaviside_uv", c.name()),
+                              category=RuntimeWarning)
             continue
 
         elif require_heaviside_t(c.item_code) and heaviside_t is None:
             if verbose:
-                warnings.warn(msg.format("heaviside_t", c.name()))
+                warnings.warn(msg.format("heaviside_t", c.name()),
+                              category=RuntimeWarning)
             continue
 
         yield c


### PR DESCRIPTION
Closes #135 .

This PR provides a warning type & captures cube drop warnings to keep test output clean.

Any comments welcome!
