### PR TITLE
Capture filename key warning in test

### DIFF
--- a/test/test_conversion_driver_esm1p5.py
+++ b/test/test_conversion_driver_esm1p5.py
@@ -80,11 +80,16 @@ def test_get_nc_write_path_unrecognized_unit():
     nc_write_dir = Path("netCDF")
     expected_nc_write_path = nc_write_dir / f"aiihca.p{unknown_key}-005007.nc"
 
-    nc_write_path = esm1p5_convert.get_nc_write_path(
-                        Path(ff_name),
-                        nc_write_dir,
-                        (ff_year, ff_month, 1)
-                    )
+    with pytest.warns(RuntimeWarning) as record:
+        nc_write_path = esm1p5_convert.get_nc_write_path(
+                            Path(ff_name),
+                            nc_write_dir,
+                            (ff_year, ff_month, 1)
+                        )
+        if not record:
+            msg = ("No warning with unknown filename key "
+                   f"'{unknown_key}' in '{ff_name}'")
+            pytest.fail(msg)
 
     assert nc_write_path == expected_nc_write_path
 

--- a/test/test_conversion_driver_esm1p5.py
+++ b/test/test_conversion_driver_esm1p5.py
@@ -80,16 +80,12 @@ def test_get_nc_write_path_unrecognized_unit():
     nc_write_dir = Path("netCDF")
     expected_nc_write_path = nc_write_dir / f"aiihca.p{unknown_key}-005007.nc"
 
-    with pytest.warns(RuntimeWarning) as record:
+    with pytest.warns(RuntimeWarning):
         nc_write_path = esm1p5_convert.get_nc_write_path(
                             Path(ff_name),
                             nc_write_dir,
                             (ff_year, ff_month, 1)
                         )
-        if not record:
-            msg = ("No warning with unknown filename key "
-                   f"'{unknown_key}' in '{ff_name}'")
-            pytest.fail(msg)
 
     assert nc_write_path == expected_nc_write_path
 

--- a/umpost/conversion_driver_esm1p5.py
+++ b/umpost/conversion_driver_esm1p5.py
@@ -153,7 +153,7 @@ def get_nc_filename(fields_file_name, date=None):
         warnings.warn(
             f"Unit code '{unit}' from filename f{fields_file_name} "
             "not recognized. Frequency information will not be added "
-            "to the netCDF filename."
+            "to the netCDF filename.", RuntimeWarning
         )
         suffix = ""
 


### PR DESCRIPTION
Closes #137 

This PR captures the unknown file name key warning produced by `get_nc_filename()` and tests that it occurs in `test_get_nc_write_path_unrecognized_unit()`.