### PR TITLE
Extract time coord dimension fix

### DIFF
--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -395,19 +395,14 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
                     print("Transpose to", neworder)
 
                 cube.transpose(neworder)
-
-            sman.write(cube,
-                       zlib=True,
-                       complevel=compression,
-                       unlimited_dimensions=['time'],
-                       fill_value=fill_value)
         else:
-            tmp = iris.util.new_axis(cube, cube.coord('time'))
-            sman.write(tmp,
-                       zlib=True,
-                       complevel=compression,
-                       unlimited_dimensions=['time'],
-                       fill_value=fill_value)
+            cube = iris.util.new_axis(cube, cube.coord('time'))
+
+        sman.write(cube,
+                   zlib=True,
+                   complevel=compression,
+                   unlimited_dimensions=['time'],
+                   fill_value=fill_value)
 
     except iris.exceptions.CoordinateNotFoundError:
         # No time dimension (probably ancillary file)

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -380,7 +380,7 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
         if coord.points.dtype == np.int64:
             coord.points = coord.points.astype(np.int32)
 
-    cube, unlimited_dimension = fix_time_coord(cube, verbose)
+    cube, unlimited_dimensions = fix_time_coord(cube, verbose)
 
     # TODO: refactor & move to end of process()
     # TODO: refactor cubewrite() to return (cube, unlimited dims, fill value)
@@ -388,7 +388,7 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
     sman.write(cube,
                zlib=True,
                complevel=compression,
-               unlimited_dimensions=unlimited_dimension,
+               unlimited_dimensions=unlimited_dimensions,
                fill_value=fill_value)
 
 

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -965,6 +965,23 @@ def convert_32_bit(cube):
 
 
 def fix_time_coord(cube, verbose):
+    """
+    Ensures cube has a 'time' coordinate dimension.
+
+    Coordinate dimensions are reordered to ensure 'time' is the first dimension.
+    Cubes are modified in place, although it is possible iris will return new
+    copies of cubes. UM ancillary files are ignored.
+
+    Parameters
+    ----------
+    cube : iris Cube object
+    verbose : True to display information on stdout
+
+    Returns
+    -------
+    A (cube, unlimited_dimensions) tuple. Unlimited dimensions is None for
+    ancillary files.
+    """
     try:
         # If time is a dimension but not a coordinate dimension, coord_dims('time')
         # returns empty tuple

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -382,6 +382,9 @@ def cubewrite(cube, sman, compression, use64bit, verbose):
 
     cube, unlimited_dimension = fix_time_coord(cube, verbose)
 
+    # TODO: refactor & move to end of process()
+    # TODO: refactor cubewrite() to return (cube, unlimited dims, fill value)
+    #       then move above steps into process() / remove cubewrite()
     sman.write(cube,
                zlib=True,
                complevel=compression,

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -970,7 +970,7 @@ def fix_time_coord(cube, verbose):
 
     Coordinate dimensions are reordered to ensure 'time' is the first dimension.
     Cubes are modified in place, although it is possible iris will return new
-    copies of cubes. UM ancillary files are ignored.
+    copies of cubes. UM ancillary files with no time dimension are ignored.
 
     Parameters
     ----------
@@ -980,7 +980,7 @@ def fix_time_coord(cube, verbose):
     Returns
     -------
     A (cube, unlimited_dimensions) tuple. Unlimited dimensions is None for
-    ancillary files.
+    ancillary files with no time dimension.
     """
     try:
         # If time is a dimension but not a coordinate dimension, coord_dims('time')

--- a/umpost/um2netcdf.py
+++ b/umpost/um2netcdf.py
@@ -966,7 +966,8 @@ def convert_32_bit(cube):
 
 def fix_time_coord(cube, verbose):
     try:
-        # If time is a dimension but not a coordinate dimension, coord_dims('time') returns empty tuple
+        # If time is a dimension but not a coordinate dimension, coord_dims('time')
+        # returns empty tuple
         if tdim := cube.coord_dims('time'):
             # For fields with a pseudo-level, time may not be the first dimension
             if tdim != (0,):
@@ -976,11 +977,13 @@ def fix_time_coord(cube, verbose):
                 neworder.insert(0, tdim)
 
                 if verbose > 1:
+                    # TODO: fix I/O, is this better as a warning?
                     print("Incorrect dimension order", cube)
                     print("Transpose to", neworder)
 
                 cube.transpose(neworder)
         else:
+            # TODO: does this return a new copy or modified cube?
             cube = iris.util.new_axis(cube, cube.coord('time'))
 
         unlimited_dimensions = ['time']


### PR DESCRIPTION
Closes #142.

This PR covers refactoring: extracting the time coord fix function & decoupling from the file I/O write process. Tests are intended for work on #143. I've tested this with the [binary diff script](https://github.com/ACCESS-NRI/um2nc-standalone/blob/main/integration/binary_diff.sh).

This is a step closer to combining `process()` and `cubewrite()` for a single workflow function to rule them all.

Any comments welcome!