### PR TITLE
Add basic usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,40 +25,6 @@ To install it run:
 conda install accessnri::um2nc
 ```
 
-## Development/Testing instructions
-For development/testing, it is recommended to install `um2nc` as a development package within a `micromamba`/`conda` testing environment.
-
-### Clone um2nc-standalone GitHub repo
-```
-git clone git@github.com:ACCESS-NRI/um2nc-standalone.git
-```
-
-### Create a micromamba/conda testing environment
-> [!TIP]  
-> In the following instructions `micromamba` can be replaced with `conda`.
-
-```
-cd um2nc-standalone
-micromamba env create -n um2nc_dev --file .conda/env_dev.yml
-micromamba activate um2nc_dev
-```
-
-### Install um2nc as a development package
-```
-pip install --no-deps --no-build-isolation -e .
-```
-
-### Running the tests
-
-The `um2nc-standalone` project uses `pytest` and `pytest-cov`.<br>
-To run the tests and generate a coverage report (with missing lines) run:
-
-```
-python3 -m pytest --cov-report=term-missing --cov=um2nc
-```
-> [!TIP]
-> To generate an HTML coverage report substitute `term-missing` with `html`.
-
 ## Usage instructions
 
 `um2nc` utilities for converting UM files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
@@ -137,6 +103,41 @@ esmp1p5_convert_nc [options] current_output_dir
 ### Supported files
 
 `um2nc` supports the conversion of Unified Model output and restart files. Ancillary files and files containing timeseries are currently not supported.
+
+
+## Development/Testing instructions
+For development/testing, it is recommended to install `um2nc` as a development package within a `micromamba`/`conda` testing environment.
+
+### Clone um2nc-standalone GitHub repo
+```
+git clone git@github.com:ACCESS-NRI/um2nc-standalone.git
+```
+
+### Create a micromamba/conda testing environment
+> [!TIP]  
+> In the following instructions `micromamba` can be replaced with `conda`.
+
+```
+cd um2nc-standalone
+micromamba env create -n um2nc_dev --file .conda/env_dev.yml
+micromamba activate um2nc_dev
+```
+
+### Install um2nc as a development package
+```
+pip install --no-deps --no-build-isolation -e .
+```
+
+### Running the tests
+
+The `um2nc-standalone` project uses `pytest` and `pytest-cov`.<br>
+To run the tests and generate a coverage report (with missing lines) run:
+
+```
+python3 -m pytest --cov-report=term-missing --cov=um2nc
+```
+> [!TIP]
+> To generate an HTML coverage report substitute `term-missing` with `html`.
 
 ## Further information
 `um2nc` is developed and supported by [ACCESS-NRI](https://www.access-nri.org.au/) to facilitate the use of [ACCESS models](https://access-hive.org.au/models/) and data.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ module use /g/data/vk83/modules
 module load payu
 ```
 > [!IMPORTANT]  
-> You need to be a member of the vk83 project on NCI to access the module. For more information check how to [Join relevant NCI projects](https://access-hive.org.au/getting_started/set_up_nci_account/#join-relevant-nci-projects)
+> You need to be a member of the `vk83` project on NCI to access the module. For more information check how to [Join relevant NCI projects](https://access-hive.org.au/getting_started/set_up_nci_account/#join-relevant-nci-projects)
 
 ### Local installation
 `um2nc` is available as a `conda` package in the [access-nri conda channel](https://anaconda.org/accessnri/um2nc).
@@ -51,7 +51,7 @@ pip install --no-deps --no-build-isolation -e .
 ### Running the tests
 
 The `um2nc-standalone` project uses `pytest` and `pytest-cov`.<br>
-To run the tests and generate print a coverage report (with missing lines) run:
+To run the tests and generate a coverage report (with missing lines) run:
 
 ```
 python3 -m pytest --cov-report=term-missing --cov=um2nc

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ um2nc [options] infile outfile
 **Positional Arguments**
 - `infile` The path of the UM input file to convert to netCDF.
 - `outfile` The path of the netCDF output file.
+
 **Optional Arguments**
+
 _User information options:_
 * `-h, --help` Display a help message and exit.
 * `-v, --verbose`  Display verbose output (use `-vv` for the highest level of output).
@@ -64,7 +66,7 @@ Points on a pressure level grid may fall below ground-level in some fields of th
 
 By default, variables on pressure level grids that fall below-ground level will be masked with the appropriate Heaviside variable found in the input file. If the Heaviside variable cannot be found, these variables will be omitted from the output. This behaviour can be controlled by the following options:
 
-`--hcrit HCRIT` Minimum fraction of the time spent above ground-level for a pressure grid data point to be considered valid.  Data points in pressure grid variables will be masked if they were above ground-level for less than the critical fraction `HCRIT` of the time. This option has no effect when used together with the `--nomask` option. Default `0.5`.
+* `--hcrit HCRIT` Minimum fraction of the time spent above ground-level for a pressure grid data point to be considered valid.  Data points in pressure grid variables will be masked if they were above ground-level for less than the critical fraction `HCRIT` of the time. This option has no effect when used together with the `--nomask` option. Default `0.5`.
 * `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to the output file regardless of the presence of the Heaviside variable.
 
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ _User information options:_
 * `-v, --verbose`  Display verbose output (use `-vv` for the highest level of output).
 
 _Output file format options:_
-* `-k NC_KIND` netCDF output format. Options `1`: classic, `2`: 64-bit offset, `3`: netCDF-4, `4`: netCDF-4 classic model. Default `3`.
-* `-c COMPRESSION` netCDF compression level (`0`=none, `9`=max). Default `4`.
+* `-k NC_KIND` NetCDF output format. Choose among `1` (classic), `2` (64-bit offset), `3` (netCDF-4), `4` (netCDF-4 classic). Default: `3` (netCDF-4).
+* `-c COMPRESSION` NetCDF compression level. `0` (none) to `9` (max). Default: `4`.
 * `--64` Write 64 bit output when input is 64 bit. When absent, output will be 32 bit.
 
 _Variable selection options:_

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Unified Model to netCDF Post-processing: um2nc
+# um2nc: Unified Model to netCDF post-processing
 
 ## About
 
-`um2nc` is a `Python3` utility for converting [Unified Model data files](https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf) to netCDF format. `um2nc` is developed by [ACCESS-NRI](https://www.access-nri.org.au/) to support users of ACCESS models that contain a Unified Model component, including [ACCESS-CM2](https://access-hive.org.au/models/configurations/access-cm/) and [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/).
+`um2nc` is a `Python` utility for converting [Unified Model (UM) data files](https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf) to netCDF format. `um2nc` is developed by [ACCESS-NRI](https://www.access-nri.org.au/) to support users of ACCESS models that contain a Unified Model component, including [ACCESS-CM2](https://access-hive.org.au/models/configurations/access-cm/) and [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/).
 
 
 ## Installation
@@ -61,65 +61,70 @@ python3 -m pytest --cov-report=term-missing --cov=um2nc
 
 ## Usage instructions
 
-`um2nc` utilities for converting Unified Model files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
+`um2nc` utilities for converting UM files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
 * [`um2nc`](#um2nc)
 * [`esm1p5_convert_nc`](#esm1p5_convert_nc)
 
 ### `um2nc`
-The `um2nc` command converts a single Unified Model data file `infile` to a netCDF file `outfile`, and is used as follows:
+The `um2nc` command converts a single UM file to a netCDF file.
+
+**Usage**
 ```
 um2nc [options] infile outfile
 ```
-The following options are available for configuring the conversion:
-
-**User information options**:
+**Positional Arguments**
+- `infile` The path of the UM input file to convert to netCDF.
+- `outfile` The path of the netCDF output file.
+**Optional Arguments**
+_User information options:_
 * `-h, --help` Display a help message and exit.
 * `-v, --verbose`  Display verbose output (use `-vv` for the highest level of output).
 
-**Output file format options**:
+_Output file format options:_
 * `-k NC_KIND` netCDF output format. Options `1`: classic, `2`: 64-bit offset, `3`: netCDF-4, `4`: netCDF-4 classic model. Default `3`.
 * `-c COMPRESSION` netCDF compression level (`0`=none, `9`=max). Default `4`.
 * `--64` Write 64 bit output when input is 64 bit. When absent, output will be 32 bit.
 
-**Variable selection options**:
+_Variable selection options:_
 
-* `--include ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to include in the output, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. Any other variables present in `infile` will not be written to `outfile`.
-* `--exclude ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to exclude from the output, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. All other variables present in `infile` will be written to `outfile`.
+* `--include ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to include in the output file, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. Any other variables present in the input file will not be written to the output file.
+* `--exclude ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to exclude from the output file, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. All other variables present in input file will be written to output file.
 
-The options `--include` and `--exclude` cannot be used simultaneously. When neither are present, all variables in `infile` will be written to `outfile`.
+The options `--include` and `--exclude` cannot be used simultaneously. When neither are present, all variables in the input file will be written to the output file.
 
-**Masking options**:
+_Masking options:_
 
-Points on a pressure level grid may fall below ground-level for some of the duration represented by a data point in the input `infile`. When heaviside masking is enabled, pressure level data at a given location will be masked if it fell below ground-level for longer than a critical fraction (`HCRIT`) of the time.
+Points on a pressure level grid may fall below ground-level in some fields of the input file. When Heaviside masking is enabled, pressure level data that falls below ground-level for longer than the critical time fraction `HCRIT` will be masked.
 
-By default, variables on pressure level grids will be masked by the appropriate heaviside variable found in `infile`. If the heaviside variable cannot be found, these variables will be omitted from the output `outfile`. This behaviour is modified by the following options:
+By default, variables on pressure level grids that fall below-ground level will be masked with the appropriate Heaviside variable found in the input file. If the Heaviside variable cannot be found, these variables will be omitted from the output. This behaviour can be controlled by the following options:
 
 * `--hcrit HCRIT` Critical value of heaviside variable for pressure level masking. Has no effect if the required heaviside variable is missing, or if `--nomask` is selected. Default `0.5`.
-* `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to `outfile` regardless of the presence of the heaviside variable.
+* `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to the output file regardless of the presence of the Heaviside variable.
 
 
-**Metadata options**:
+_Metadata options:_
 
 * `--model MODEL` Link STASH codes to variable names and metadata using a preset STASHmaster associated with a specific model. Supported options are `cmip6`, `access-cm2`, `access-esm1.5`, and `access-esm1.6`. If omitted, the `cmip6` STASHmaster will be used.
-* `--nohist` Don't write a global history attribute to `outfile`. When absent, the conversion time, `um2nc` project version, and the script location will be written to the `history` attribute.
-* `--simple` Use the simple variable naming scheme. Variables in `outfile` will be named based on their STASH section number and item code: `fld_s<section number>i<item number>`. When absent, variable names will be taken from the selected `STASHmaster` (see the `--model` argument).
+* `--nohist` Don't add a global history attribute to the output file. When absent, the conversion time, `um2nc` version, and the script location will be added to the `history` global netCDF attribute.
+* `--simple` Use the simple variable naming scheme. Variables in the output file will be named based on their STASH section number and item code, in the format `fld_s<section number>i<item number>`. When absent, variable names will be taken from the selected `STASHmaster` (see the `--model` argument).
 
 
 ### `esm1p5_convert_nc`
 
-The `esmp1p5_convert_nc` command is designed to be run automatically during [`payu`](https://payu.readthedocs.io/en/stable/) based simulation of [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/). It converts all Unified Model output files from a single run to netCDF, and is typically included in a simulation as a `payu` [userscript](https://payu.readthedocs.io/en/stable/config.html#postprocessing).
+The `esmp1p5_convert_nc` command is designed to be run automatically during [`payu`](https://payu.readthedocs.io/en/stable/) based simulation of [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/). It converts all UM output files from a single experiment run to netCDF, and is typically included in a simulation as a `payu` [userscript](https://payu.readthedocs.io/en/stable/config.html#postprocessing).
 
-The `esm1p5_convert_nc` command is used as follows:
+**Usage**
 
 ```
 esmp1p5_convert_nc [options] current_output_dir
 ```
 
-The positional argument `current_output_dir` specifies the path to an ACCESS-ESM1.5 simulation's output directory. Any Unified Model output files in the `current_output_dir/atmosphere` subdirectory will be converted to netCDF and placed in a new directory `current_output_dir/atmosphere/netCDF`.
+**Positional arguments**
+- `current_output_dir` Path to an `ACCESS-ESM1.5` simulation's output directory. Any UM output files in the `current_output_dir/atmosphere` subdirectory will be converted to netCDF and placed in a new directory `current_output_dir/atmosphere/netCDF`.
 
-The following options are available for the `esmp1p5_convert_nc`:
+**Optional Arguments**
 
-* `--help, -h` Show a help message and exit.
+* `--help, -h` Display a help message and exit.
 * `--delete-ff, -d`  Delete Unified Model output files upon successful conversion.
 * `--quiet, -q` Report only final exception type and message for any expected `um2nc` exceptions raised during conversion. If absent, full stack traces are reported.
 
@@ -131,10 +136,10 @@ The following options are available for the `esmp1p5_convert_nc`:
 
 ### Supported files
 
-`um2nc` supports the conversion of Unified Model output and restart files. Time series and ancillary files are not currently supported.
+`um2nc` supports the conversion of Unified Model output and restart files. Ancillary files and files containing timeseries are currently not supported.
 
 ## Further information
 `um2nc` is developed and supported by [ACCESS-NRI](https://www.access-nri.org.au/) to facilitate the use of [ACCESS models](https://access-hive.org.au/models/) and data.
-Requests for support in using `um2nc` can be made on the [ACCESS-HIVE Forum](https://forum.access-hive.org.au/). Bug reports and suggestions can be submitted as [GitHub issues](https://github.com/ACCESS-NRI/um2nc-standalone/issues).
+Requests for support in using `um2nc` can be made on the [ACCESS-HIVE Forum](https://forum.access-hive.org.au/). Bug reports and suggestions are welcomed as [GitHub issues](https://github.com/ACCESS-NRI/um2nc-standalone/issues).
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# Unified Model to NetCDF Post-processing: um2nc
+# Unified Model to netCDF Post-processing: um2nc
 
 ## About
 
-`um2nc` is a `Python3` utility to convert [Unified Model data files](https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf) to NetCDF format.
+`um2nc` is a `Python3` utility for converting [Unified Model data files](https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf) to netCDF format. `um2nc` is developed by [ACCESS-NRI](https://www.access-nri.org.au/) to support users of ACCESS models that contain a Unified Model component, including [ACCESS-CM2](https://access-hive.org.au/models/configurations/access-cm/) and [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/).
 
-The `um2nc-standalone` project is an [ACCESS-NRI](https://www.access-nri.org.au/) initiative to merge multiple versions of Unified Model NetCDF conversion tool to a single, canonical project. 
 
 ## Installation
 
@@ -60,14 +59,82 @@ python3 -m pytest --cov-report=term-missing --cov=um2nc
 > [!TIP]
 > To generate an HTML coverage report substitute `term-missing` with `html`.
 
-## User documentation
+## Usage instructions
 
-TODO: this needs to cover:
+`um2nc` utilities for converting Unified Model files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
+* [`um2nc`](#um2nc)
+* [`esm1p5_convert_nc`](#esm1p5_convert_nc)
 
-1. Running `um2netcdf` standalone
-2. Using the workflow run script
-3. Using `um2netcdf` as an API
+### `um2nc`
+The `um2nc` command converts a single Unified Model data file `infile` to a netCDF file `outfile`, and is used as follows:
+```
+um2nc [options] infile outfile
+```
+The following options are available for configuring the conversion:
+
+**User information options**:
+* `-h, --help` Display a help message and exit.
+* `-v, --verbose`  Display verbose output (use `-vv` for the highest level of output).
+
+**Output file format options**:
+* `-k NC_KIND` netCDF output format. Options `1`: classic, `2`: 64-bit offset, `3`: netCDF-4, `4`: netCDF-4 classic model. Default `3`.
+* `-c COMPRESSION` netCDF compression level (`0`=none, `9`=max). Default `4`.
+* `--64` Write 64 bit output when input is 64 bit. When absent, output will be 32 bit.
+
+**Variable selection options**:
+
+* `--include ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to include in the output, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. Any other variables present in `infile` will not be written to `outfile`.
+* `--exclude ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to exclude from the output, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. All other variables present in `infile` will be written to `outfile`.
+
+The options `--include` and `--exclude` cannot be used simultaneously. When neither are present, all variables in `infile` will be written to `outfile`.
+
+**Masking options**:
+
+Points on a pressure level grid may fall below ground-level for some of the duration represented by a data point in the input `infile`. When heaviside masking is enabled, pressure level data at a given location will be masked if it fell below ground-level for longer than a critical fraction (`HCRIT`) of the time.
+
+By default, variables on pressure level grids will be masked by the appropriate heaviside variable found in `infile`. If the heaviside variable cannot be found, these variables will be omitted from the output `outfile`. This behaviour is modified by the following options:
+
+* `--hcrit HCRIT` Critical value of heaviside variable for pressure level masking. Has no effect if the required heaviside variable is missing, or if `--nomask` is selected. Default `0.5`.
+* `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to `outfile` regardless of the presence of the heaviside variable.
+
+
+**Metadata options**:
+
+* `--model MODEL` Link STASH codes to variable names and metadata using a preset STASHmaster associated with a specific model. Supported options are `cmip6`, `access-cm2`, `access-esm1.5`, and `access-esm1.6`. If omitted, the `cmip6` STASHmaster will be used.
+* `--nohist` Don't write a global history attribute to `outfile`. When absent, the conversion time, `um2nc` project version, and the script location will be written to the `history` attribute.
+* `--simple` Use the simple variable naming scheme. Variables in `outfile` will be named based on their STASH section number and item code: `fld_s<section number>i<item number>`. When absent, variable names will be taken from the selected `STASHmaster` (see the `--model` argument).
+
+
+### `esm1p5_convert_nc`
+
+The `esmp1p5_convert_nc` command is designed to be run automatically during [`payu`](https://payu.readthedocs.io/en/stable/) based simulation of [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/). It converts all Unified Model output files from a single run to netCDF, and is typically included in a simulation as a `payu` [userscript](https://payu.readthedocs.io/en/stable/config.html#postprocessing).
+
+The `esm1p5_convert_nc` command is used as follows:
+
+```
+esmp1p5_convert_nc [options] current_output_dir
+```
+
+The positional argument `current_output_dir` specifies the path to an ACCESS-ESM1.5 simulation's output directory. Any Unified Model output files in the `current_output_dir/atmosphere` subdirectory will be converted to netCDF and placed in a new directory `current_output_dir/atmosphere/netCDF`.
+
+The following options are available for the `esmp1p5_convert_nc`:
+
+* `--help, -h` Show a help message and exit.
+* `--delete-ff, -d`  Delete Unified Model output files upon successful conversion.
+* `--quiet, -q` Report only final exception type and message for any expected `um2nc` exceptions raised during conversion. If absent, full stack traces are reported.
+
+`esm1p5_convert_nc` uses the same underlying workflow as the `um2nc` command to convert each file, and applies the following arguments:
+* `-k 3`
+* `-c 4`
+* `--simple`
+* `--hcrit 0.5`
+
+### Supported files
+
+`um2nc` supports the conversion of Unified Model output and restart files. Time series and ancillary files are not currently supported.
 
 ## Further information
+`um2nc` is developed and supported by [ACCESS-NRI](https://www.access-nri.org.au/) to facilitate the use of [ACCESS models](https://access-hive.org.au/models/) and data.
+Requests for support in using `um2nc` can be made on the [ACCESS-HIVE Forum](https://forum.access-hive.org.au/). Bug reports and suggestions can be submitted as [GitHub issues](https://github.com/ACCESS-NRI/um2nc-standalone/issues).
 
-TODO
+

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ The options `--include` and `--exclude` cannot be used simultaneously. When neit
 
 _Masking options:_
 
-Points on a pressure level grid may fall below ground-level in some fields of the input file. When Heaviside masking is enabled, pressure level data that falls below ground-level for longer than the critical time fraction `HCRIT` will be masked.
+Points on a pressure level grid may fall below ground-level in some fields of the input file. When Heaviside masking is enabled, pressure level data that were located above ground-level for less than the critical time fraction `HCRIT` will be masked.
 
 By default, variables on pressure level grids that fall below-ground level will be masked with the appropriate Heaviside variable found in the input file. If the Heaviside variable cannot be found, these variables will be omitted from the output. This behaviour can be controlled by the following options:
 
-* `--hcrit HCRIT` Critical value of heaviside variable for pressure level masking. Has no effect if the required heaviside variable is missing, or if `--nomask` is selected. Default `0.5`.
+`--hcrit HCRIT` Minimum fraction of the time spent above ground-level for a pressure grid data point to be considered valid.  Data points in pressure grid variables will be masked if they were above ground-level for less than the critical fraction `HCRIT` of the time. This option has no effect when used together with the `--nomask` option. Default `0.5`.
 * `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to the output file regardless of the presence of the Heaviside variable.
 
 

--- a/src/um2nc/conversion_driver_esm1p5.py
+++ b/src/um2nc/conversion_driver_esm1p5.py
@@ -402,13 +402,13 @@ def parse_args():
     parser.add_argument("--quiet", "-q", action="store_true",
                         help=(
                             "Report only final exception type and message for "
-                            "allowed exceptions raised during conversion when "
-                            "flag is included. Otherwise report full "
-                            "stack trace."
+                            "any expected `um2nc` exceptions raised during "
+                            "conversion. If absent, full stack traces "
+                            "are reported"
                         )
                         )
     parser.add_argument("--delete-ff", "-d", action="store_true",
-                        help="Delete fields files upon successful conversion."
+                        help="Delete fields files upon successful conversion"
                         )
 
     return parser.parse_args()

--- a/src/um2nc/um2netcdf.py
+++ b/src/um2nc/um2netcdf.py
@@ -1077,7 +1077,7 @@ def parse_args():
         default=3,
         help=(
             "NetCDF output format. Choose among '1' (classic), '2' (64-bit offset),"
-            '3' (netCDF-4), '4' (netCDF-4 classic). Default: '3' (netCDF-4)."
+            "'3' (netCDF-4), '4' (netCDF-4 classic). Default: '3' (netCDF-4)."
         ),
         choices=[1, 2, 3, 4],
     )

--- a/src/um2nc/um2netcdf.py
+++ b/src/um2nc/um2netcdf.py
@@ -1068,7 +1068,7 @@ def fix_time_coord(cube, verbose):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Convert UM fieldsfile to netcdf")
+    parser = argparse.ArgumentParser(description="Convert UM fieldsfile to netCDF")
     parser.add_argument(
         "-k",
         dest="nckind",
@@ -1076,9 +1076,9 @@ def parse_args():
         type=int,
         default=3,
         help=(
-            "specify netCDF output format: 1 classic, 2 64-bit"
-            " offset, 3 netCDF-4, 4 netCDF-4 classic model."
-            " Default 3"
+            "netCDF output format: Options '1' classic, '2' 64-bit"
+            " offset, '3' netCDF-4, '4' netCDF-4 classic model."
+            " Default '3'"
         ),
         choices=[1, 2, 3, 4],
     )
@@ -1088,13 +1088,13 @@ def parse_args():
         required=False,
         type=int,
         default=4,
-        help="compression level (0=none, 9=max). Default 4",
+        help="Compression level ('0'=none, '9'=max). Default '4'",
     )
     parser.add_argument(
-        "--64", dest="use64bit", action="store_true", default=False, help="Use 64 bit netcdf for 64 bit input"
+        "--64", dest="use64bit", action="store_true", default=False, help="Write 64 bit output when input is 64 bit"
     )
     parser.add_argument(
-        "-v", "--verbose", dest="verbose", action="count", default=0, help="verbose output (-vv for extra verbose)"
+        "-v", "--verbose", dest="verbose", action="count", default=0, help="Display verbose output (use '-vv' for the highest level of output)"
     )
 
     group = parser.add_mutually_exclusive_group()
@@ -1106,20 +1106,20 @@ def parse_args():
         dest="nomask",
         action="store_true",
         default=False,
-        help="Don't apply heaviside function mask to pressure level fields",
+        help="Don't mask variables on pressure level grids",
     )
     parser.add_argument(
-        "--nohist", dest="nohist", action="store_true", default=False, help="Don't update history attribute"
+        "--nohist", dest="nohist", action="store_true", default=False, help="Don't write a global history attribute to the output"
     )
     parser.add_argument(
-        "--simple", dest="simple", action="store_true", default=False, help="Use a simple names of form fld_s01i123."
+        "--simple", dest="simple", action="store_true", default=False, help="Use simple names of form 'fld_s<section number>i<item number>'"
     )
     parser.add_argument(
         "--hcrit",
         dest="hcrit",
         type=float,
         default=0.5,
-        help=("Critical value of heavyside fn for pressure level" " masking (default=0.5)"),
+        help=("Critical value of heaviside variable for pressure level masking. Default '0.5'"),
     )
 
     parser.add_argument("infile", help="Input file")

--- a/src/um2nc/um2netcdf.py
+++ b/src/um2nc/um2netcdf.py
@@ -1068,7 +1068,7 @@ def fix_time_coord(cube, verbose):
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Convert UM fieldsfile to netCDF")
+    parser = argparse.ArgumentParser(description="Convert UM fieldsfile to netCDF.")
     parser.add_argument(
         "-k",
         dest="nckind",
@@ -1076,9 +1076,8 @@ def parse_args():
         type=int,
         default=3,
         help=(
-            "netCDF output format: Options '1' classic, '2' 64-bit"
-            " offset, '3' netCDF-4, '4' netCDF-4 classic model."
-            " Default '3'"
+            "NetCDF output format. Choose among '1' (classic), '2' (64-bit offset),"
+            '3' (netCDF-4), '4' (netCDF-4 classic). Default: '3' (netCDF-4)."
         ),
         choices=[1, 2, 3, 4],
     )
@@ -1088,13 +1087,13 @@ def parse_args():
         required=False,
         type=int,
         default=4,
-        help="Compression level ('0'=none, '9'=max). Default '4'",
+        help="Compression level. '0' (none) to '9' (max). Default: '4'",
     )
     parser.add_argument(
         "--64", dest="use64bit", action="store_true", default=False, help="Write 64 bit output when input is 64 bit"
     )
     parser.add_argument(
-        "-v", "--verbose", dest="verbose", action="count", default=0, help="Display verbose output (use '-vv' for the highest level of output)"
+        "-v", "--verbose", dest="verbose", action="count", default=0, help="Display verbose output (use '-vv' for extra verbosity)."
     )
 
     group = parser.add_mutually_exclusive_group()
@@ -1106,20 +1105,20 @@ def parse_args():
         dest="nomask",
         action="store_true",
         default=False,
-        help="Don't mask variables on pressure level grids",
+        help="Don't mask variables on pressure level grids.",
     )
     parser.add_argument(
-        "--nohist", dest="nohist", action="store_true", default=False, help="Don't write a global history attribute to the output"
+        "--nohist", dest="nohist", action="store_true", default=False, help="Don't add/update the global 'history' attribute in the output netCDF."
     )
     parser.add_argument(
-        "--simple", dest="simple", action="store_true", default=False, help="Use simple names of form 'fld_s<section number>i<item number>'"
+        "--simple", dest="simple", action="store_true", default=False, help="Write output using simple variable names of format 'fld_s<section number>i<item number>'."
     )
     parser.add_argument(
         "--hcrit",
         dest="hcrit",
         type=float,
         default=0.5,
-        help=("Critical value of heaviside variable for pressure level masking. Default '0.5'"),
+        help=("Critical value of the Heaviside variable for pressure level masking. Default: '0.5'."),
     )
 
     parser.add_argument("infile", help="Input file")


### PR DESCRIPTION
This PR closes #164. It adds basic usage instructions to the `README.md` file, outlining the available commands and options.

It also modifies the `argparse` help strings for clarity and grammatical consistency.

Any suggestions or feedback for making the documentation clearer or more informative would be very welcome!