### PR TITLE
Update paths to regression test data

### DIFF
--- a/integration/INTEGRATION_README.md
+++ b/integration/INTEGRATION_README.md
@@ -78,4 +78,4 @@ prior to the development of `um2nc`: https://github.com/ACCESS-NRI/um2nc-standal
 The conversion was performed within the following `payu1.1.5` environment, active on Gadi:
 https://github.com/ACCESS-NRI/payu-condaenv/releases/tag/1.1.5
 
-All test data is located in `/g/data/vk83/testing/um2nc/integration-tests`.
+All test data is located in `/g/data/vk83/testing/data/um2nc/integration-tests`.

--- a/integration/regression_tests.sh
+++ b/integration/regression_tests.sh
@@ -28,7 +28,7 @@ EOF
 
 
 
-TEST_DATA_PARENT_DIR=/g/data/vk83/testing/um2nc/integration-tests
+TEST_DATA_PARENT_DIR=/g/data/vk83/testing/data/um2nc/integration-tests
 
 # Default values, overwritten by command line arguments if present:
 TEST_DATA_CHOICE_DEFAULT=intermediate


### PR DESCRIPTION
Closes #117. This pull request updates the paths for the regression test data to match its location on gadi.