### PR TITLE
Added conda_build_config to force the production of 'tar.bz2' packages

### DIFF
--- a/.conda/conda_build_config.yaml
+++ b/.conda/conda_build_config.yaml
@@ -1,0 +1,1 @@
+conda_pkg_format: tar.bz2


### PR DESCRIPTION
New versions of conda can build packages having 2 different extensions:
- `.tar.bz2`
- `.conda`

The `.conda` extension is a fairly new one. 
I think it would be best if we enforce the production of `.tar.bz2` to attach to our releases (as these files are more commonly used). To do so, the `conda_build_config.yaml` file has been added with a related field that enables that.

Also, this will fix the issue with the current error with the [release CD](https://github.com/ACCESS-NRI/um2nc-standalone/actions/runs/12858703930/job/35848192545) that is trying to build a [`.conda` package](https://github.com/ACCESS-NRI/um2nc-standalone/actions/runs/12858703930/job/35848192545#step:4:166), but the [uibcdf/action-build-and-upload-conda-packages](https://github.com/uibcdf/action-build-and-upload-conda-packages/blob/b06165145a25b9c8bcb2d2b24682ad0d8e494ce7/action.yml#L136) action only searches for `.tar.bz2` packages (I am going to open anyway a PR to the action because this is a bug).