### PR TITLE
Correctly enforce the production of `.tar.bz2` packages

### DIFF
--- a/.conda/conda_build_config.yaml
+++ b/.conda/conda_build_config.yaml
@@ -1,1 +1,0 @@
-conda_pkg_format: tar.bz2

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -45,7 +45,16 @@ jobs:
           auto-update-conda: false
           auto-activate-base: false
           show-channel-urls: true
-
+      
+      - name: Enforce .tar.bz2 packages
+        # We create a `~/.condarc` file with the correct options to enforce the use of `.tar.bz2` packages
+        shell: bash
+        run: |
+            cat > ~/.condarc << EOF
+            conda-build:
+                pkg_format: .tar.bz2
+            EOF
+      
       - name: Build and upload conda package
         id: build-and-upload
         uses: uibcdf/action-build-and-upload-conda-packages@b06165145a25b9c8bcb2d2b24682ad0d8e494ce7 #v1.4.0


### PR DESCRIPTION
After digging deeper with the `conda build` `.conda`/`.tar.bz2` packages format [issue](https://github.com/ACCESS-NRI/um2nc-standalone/pull/180), I couldn't find a correct way to enforce that with the `conda_build_config.yaml` file. 
However, in [one of the latest `conda-build` releases](https://github.com/conda/conda-build/releases/tag/25.1.0), it says:
> `.tar.bz2` files can still be generated with `--package-format=1` and/or `conda_build.pkg_format: 1` in your `.condarc` file.

Therefore, in this PR:
- [x] Removed `conda_build_config.yaml`
- [x] Added step to the release CD.yml to create the `~/.condarc` file and enforce the production of '.tar.bz2' packages.