### PR TITLE
Added label to the 'uibcdf/action-build-and-upload-conda-packages' action

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -70,6 +70,7 @@ jobs:
             python-version: ${{ vars.PY_VERSION }}
             user: ${{ secrets.ANACONDA_USER_NAME }}
             token: ${{ secrets.ANACONDA_TOKEN }}
+            label: main
             platform_all: true
           
       - name: Create Release


### PR DESCRIPTION
Another fix for the `CD.yml` release workflow:
- [x] Added `label` as an input to the `uibcdf/action-build-and-upload-conda-packages` action to fix [the error](https://github.com/ACCESS-NRI/um2nc-standalone/actions/runs/12880928576/job/35910680233#step:5:700) (again, it's a bug of the action but this is a work-around that would also work long-term)