### PR TITLE
Added support for ancillary files

### DIFF
--- a/src/um2nc/um2netcdf.py
+++ b/src/um2nc/um2netcdf.py
@@ -127,6 +127,12 @@ class EnumAction(argparse.Action):
         member = self._enum(value)
         setattr(namespace, self.dest, member)
 
+def is_ancil(infile: mule.ff.FieldsFile) -> bool:
+    """
+    Check if the mule file is an ancillary file.
+    """
+    return isinstance(infile, mule.ancil.AncilFile)
+
 # TODO: Delete when iris PR 5138 (info below) gets merged
 def fix_iris_calendar():
     """
@@ -751,7 +757,7 @@ def get_z_sea_constants(ff: mule.ff.FieldsFile):
     (z_rho, z_theta) tuple of array of floating point values.
     """
     # z_rho and z_theta are not present in ancillary files
-    if not isinstance(ff, mule.ancil.AncilFile):
+    if not is_ancil(ff):
         try:
             z_rho = ff.level_dependent_constants.zsea_at_rho
             z_theta = ff.level_dependent_constants.zsea_at_theta

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -381,17 +381,6 @@ def test_get_z_sea_constants():
 
     assert um2nc.get_z_sea_constants(ff) == (z_rho, z_theta)
 
-
-def test_ancillary_files_no_support():
-    af = mule.ancil.AncilFile()
-
-    with mock.patch("mule.load_umfile") as mload:
-        mload.return_value = af
-
-        with pytest.raises(NotImplementedError):
-            um2nc.process("fake_infile", "fake_outfile", args=None)
-
-
 def test_stash_code_to_item_code_conversion():
     m_stash_code = mock.Mock()
     m_stash_code.section = 30

--- a/test/test_um2netcdf.py
+++ b/test/test_um2netcdf.py
@@ -223,7 +223,7 @@ def test_process_cubes_no_heaviside_drop_cubes(ta_plev_cube, precipitation_flux_
     # include cubes requiring both heaviside uv & t cubes to filter, to
     # ensure both uv/t dependent cubes are dropped
     cubes = [ta_plev_cube, precipitation_flux_cube, geo_potential_cube]
-
+    is_ancillary = False
     # mock fix_time_coord to avoid adding difficult to replicate
     # iris methods in DummyCube.
     with (
@@ -233,13 +233,12 @@ def test_process_cubes_no_heaviside_drop_cubes(ta_plev_cube, precipitation_flux_
         m_time_coord.side_effect = mock_fix_time_no_time_dim
 
         std_args.verbose = True  # test some warning branches
-
         # trying to mask None will break in numpy
         assert precipitation_flux_cube.data is None
 
         # air temp & geo potential should be dropped in process()
         with pytest.warns(RuntimeWarning):
-            processed = tuple(um2nc.process_cubes(cubes, mule_vars, std_args))
+            processed = tuple(um2nc.process_cubes(cubes, mule_vars, std_args, is_ancillary))
 
     assert len(processed) == 1
     cube, _, dim = processed[0]
@@ -256,8 +255,8 @@ def test_process_cubes_all_cubes_filtered(ta_plev_cube, geo_potential_cube,
     """
     Ensure process_cubes() exits early if all cubes are removed in filtering.
     """
-
     cubes = [ta_plev_cube, geo_potential_cube]
+    is_ancillary = False
     # mock fix_time_coord to avoid adding difficult to replicate
     # iris methods in DummyCube.
     with (
@@ -267,7 +266,7 @@ def test_process_cubes_all_cubes_filtered(ta_plev_cube, geo_potential_cube,
         m_time_coord.side_effect = mock_fix_time_no_time_dim
 
     # all cubes should be dropped
-    assert list(um2nc.process_cubes(cubes, mule_vars, std_args)) == []
+    assert list(um2nc.process_cubes(cubes, mule_vars, std_args, is_ancillary)) == []
 
 
 def test_process_mask_with_heaviside(ta_plev_cube, precipitation_flux_cube,
@@ -280,7 +279,7 @@ def test_process_mask_with_heaviside(ta_plev_cube, precipitation_flux_cube,
     # masking, include both to enable code execution for both masks
     cubes = [ta_plev_cube, precipitation_flux_cube, geo_potential_cube,
              heaviside_uv_cube, heaviside_t_cube]
-
+    is_ancillary = False
     # mock fix_time_coord to avoid adding difficult to replicate
     # iris methods in DummyCube.
     with (
@@ -291,7 +290,7 @@ def test_process_mask_with_heaviside(ta_plev_cube, precipitation_flux_cube,
         m_time_coord.side_effect = mock_fix_time_no_time_dim
 
         # all cubes should be processed & not dropped
-        processed = list(um2nc.process_cubes(cubes, mule_vars, std_args))
+        processed = list(um2nc.process_cubes(cubes, mule_vars, std_args, is_ancillary))
 
     assert len(processed) == len(cubes)
 
@@ -306,7 +305,7 @@ def test_process_no_masking_keep_all_cubes(ta_plev_cube, precipitation_flux_cube
 
     # air temp and geo potential would need heaviside uv & t respectively
     cubes = [ta_plev_cube, precipitation_flux_cube, geo_potential_cube]
-
+    is_ancillary = False
     # mock fix_time_coord to avoid adding difficult to replicate
     # iris methods in DummyCube.
     with (
@@ -316,7 +315,7 @@ def test_process_no_masking_keep_all_cubes(ta_plev_cube, precipitation_flux_cube
         m_time_coord.side_effect = mock_fix_time_no_time_dim
 
         std_args.nomask = True
-        processed = list(um2nc.process_cubes(cubes, mule_vars, std_args))
+        processed = list(um2nc.process_cubes(cubes, mule_vars, std_args, is_ancillary))
 
     # all cubes should be kept with masking off
     assert len(processed) == len(cubes)


### PR DESCRIPTION
Fixes #101.
Fixes #8.

- [x] Removed NotSupportedError for ancillary files. 
- [x] Added 'fix_iris_calendar' function, to better manage the fixing of the iris calendar to handle proleptic gregorian calendar. Added another fix to iris, that was throwing an error when opening ancillary files with the calendar set to uf_units.CALENDAR_PROLEPTIC_GREGORIAN.**
- [x] Added is_ancil function to check if the mule file is an ancillary file.
- [x] Excluded some tasks from being performed if the input fields file is an ancillary file
- [x] Updated unit-tests
