### PR TITLE
Drop support for python 3.10

### DIFF
--- a/.conda/env_dev.yml
+++ b/.conda/env_dev.yml
@@ -7,7 +7,7 @@ channels:
 
 
 dependencies:
-    - python >=3.10,<3.13
+    - python >=3.11,<3.13
     - cf-units
     - cftime
     - f90nml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { file = "LICENSE" }
 readme = "README.md"
 keywords = ["netCDF", "UM", "postprocessing"]
 dynamic = ["version"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "cf-units",
     "cftime",


### PR DESCRIPTION
#231 sets already processed cube's data attribute to `None` in order to reduce memory usage.

However, support for setting cube data to `None` appears to have been added in iris 3.12 (compare [3.12](https://github.com/SciTools/iris/blob/e57c5d4e33dd4199077f3429724feea6a00a5685/lib/iris/_data_manager.py#L249-L252) and [3.11](https://github.com/SciTools/iris/blob/3113d368453acd6927916dfba4f366566deafdd2/lib/iris/_data_manager.py#L204-L224)), which requires python >= 3.11.


As a result, using python 3.10 results in the error:
```
Traceback (most recent call last):
  File "/scratch/tm70/sw6175/micromamba/envs/310_test/bin/um2nc", line 6, in <module>
    sys.exit(main())
  File "/g/data/tm70/sw6175/development/um2nc/um2nc-standalone/src/um2nc/cli.py", line 262, in main
    process(args.infile, args.outfile, args)
  File "/g/data/tm70/sw6175/development/um2nc/um2nc-standalone/src/um2nc/um2netcdf.py", line 518, in process
    c.data = None
  File "/scratch/tm70/sw6175/micromamba/envs/310_test/lib/python3.10/site-packages/iris/cube.py", line 2874, in data
    self._data_manager.data = data
  File "/scratch/tm70/sw6175/micromamba/envs/310_test/lib/python3.10/site-packages/iris/_data_manager.py", line 236, in data
    raise ValueError(emsg.format(self.shape, data.shape))
ValueError: Require data with shape (1, 38, 145, 192), got ().
```


This PR drops support for python 3.10 in order to prevent this error from occurring.
