### PR TITLE
Update help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,29 +28,30 @@ conda install accessnri::um2nc
 ## Usage instructions
 
 `um2nc` utilities for converting UM files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
-* [`um2nc`](#um2nc)
-* [`esm1p5_convert_nc`](#esm1p5_convert_nc)
+* [`um2nc convert`](#um2nc_convert)
+* [`um2nc driver`](#um2nc_driver)
 
-### `um2nc`
-The `um2nc` command converts a single UM file to a netCDF file.
+### `um2nc convert`
+The `um2nc convert` command converts a single UM file to a netCDF file.
 
 **Usage**
 ```
-um2nc [options] infile outfile
+um2nc convert [options] infile outfile
 ```
 **Positional Arguments**
-- `infile` The path of the UM input file to convert to netCDF.
+- `infile` The path of the UM file to convert to netCDF.
 - `outfile` The path of the netCDF output file.
 
 **Optional Arguments**
 
 _User information options:_
 * `-h, --help` Display a help message and exit.
-* `-v, --verbose`  Display verbose output (use `-vv` for the highest level of output).
+* `-v, --verbose`  Display verbose output.
+* `-q, --quiet` Suppress warnings arising from `um2nc`.
 
 _Output file format options:_
-* `-k NC_KIND` NetCDF output format. Choose among `1` (classic), `2` (64-bit offset), `3` (netCDF-4), `4` (netCDF-4 classic). Default: `3` (netCDF-4).
-* `-c COMPRESSION` NetCDF compression level. `0` (none) to `9` (max). Default: `4`.
+* `-f, --format, --nc-format, --k NC_KIND` NetCDF output format. Choose among `1` (classic), `2` (64-bit offset), `3` (netCDF-4), `4` (netCDF-4 classic). Default: `3` (netCDF-4).
+* `-c, --compression COMPRESSION` NetCDF compression level. `0` (none) to `9` (max). Default: `4`.
 * `--64` Write 64 bit output when input is 64 bit. When absent, output will be 32 bit.
 
 _Variable selection options:_
@@ -77,30 +78,25 @@ _Metadata options:_
 * `--simple` Use the simple variable naming scheme. Variables in the output file will be named based on their STASH section number and item code, in the format `fld_s<section number>i<item number>`. When absent, variable names will be taken from the selected `STASHmaster` (see the `--model` argument).
 
 
-### `esm1p5_convert_nc`
-
-The `esmp1p5_convert_nc` command is designed to be run automatically during [`payu`](https://payu.readthedocs.io/en/stable/) based simulation of [ACCESS-ESM1.5](https://access-hive.org.au/models/configurations/access-esm/). It converts all UM output files from a single experiment run to netCDF, and is typically included in a simulation as a `payu` [userscript](https://payu.readthedocs.io/en/stable/config.html#postprocessing).
+### `um2nc driver`
+`um2nc` "model drivers" convert UM fields files produced during ACCESS model simulations to netCDF. The drivers find the fields files, convert them, and organise the resulting netCDF files. As each ACCESS model has different requirements for the output format, organisation, and file naming, separate model drivers are used for each model. The model drivers are accessed via the `um2nc driver` command, which is typically run automatically from a script during a model simultion.
 
 **Usage**
 
 ```
-esmp1p5_convert_nc [options] current_output_dir
+um2nc driver [model] [options] model_directory
 ```
 
 **Positional arguments**
-- `current_output_dir` Path to an `ACCESS-ESM1.5` simulation's output directory. Any UM output files in the `current_output_dir/atmosphere` subdirectory will be converted to netCDF and placed in a new directory `current_output_dir/atmosphere/netCDF`.
+- `model` Selected model driver to use. Currently available drivers are {`esm1p5`, `esm1p6`}.
+- `model directory` Path to a simulation's output directory. For the `esm1p5` and `esm1p6` drivers, this should be a numbered `payu` `output[0-9][0-9][0-9]` directory.
 
 **Optional Arguments**
 
 * `--help, -h` Display a help message and exit.
-* `--delete-ff, -d`  Delete Unified Model output files upon successful conversion.
-* `--quiet, -q` Report only final exception type and message for any expected `um2nc` exceptions raised during conversion. If absent, full stack traces are reported.
+* `--delete-ff, -d`  Delete input files upon successful conversion.
 
-`esm1p5_convert_nc` uses the same underlying workflow as the `um2nc` command to convert each file, and applies the following arguments:
-* `-k 3`
-* `-c 4`
-* `--simple`
-* `--hcrit 0.5`
+All optional arguments from the `um2nc convert` command for configuring the netCDF conversion are also available for the `um2nc driver` command.
 
 ### Supported files
 

--- a/README.md
+++ b/README.md
@@ -27,76 +27,32 @@ conda install accessnri::um2nc
 
 ## Usage instructions
 
-`um2nc` utilities for converting UM files to netCDF can be accessed through the command line or as a `Python3` API. This user documentation details the available command line utilities:
+`um2nc` utilities for converting UM files to netCDF can be accessed through the command line. This README outlines the available command line utilities:
 * [`um2nc convert`](#um2nc_convert)
 * [`um2nc driver`](#um2nc_driver)
 
 ### `um2nc convert`
-The `um2nc convert` command converts a single UM file to a netCDF file.
+The `um2nc convert` command converts a single UM file to a netCDF file. The basic usage pattern of the `um2nc convert` command is:
 
-**Usage**
 ```
 um2nc convert [options] infile outfile
 ```
-**Positional Arguments**
-- `infile` The path of the UM file to convert to netCDF.
-- `outfile` The path of the netCDF output file.
 
-**Optional Arguments**
-
-_User information options:_
-* `-h, --help` Display a help message and exit.
-* `-v, --verbose`  Display verbose output.
-* `-q, --quiet` Suppress warnings arising from `um2nc`.
-
-_Output file format options:_
-* `-f, --format, --nc-format, --k NC_KIND` NetCDF output format. Choose among `1` (classic), `2` (64-bit offset), `3` (netCDF-4), `4` (netCDF-4 classic). Default: `3` (netCDF-4).
-* `-c, --compression COMPRESSION` NetCDF compression level. `0` (none) to `9` (max). Default: `4`.
-* `--64` Write 64 bit output when input is 64 bit. When absent, output will be 32 bit.
-
-_Variable selection options:_
-
-* `--include ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to include in the output file, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. Any other variables present in the input file will not be written to the output file.
-* `--exclude ITEM_CODE_1 [ITEM_CODE_2 ...]` List of variables to exclude from the output file, specified by their item codes. Item codes are given in the form `1000 * section number + item number`. All other variables present in input file will be written to output file.
-
-The options `--include` and `--exclude` cannot be used simultaneously. When neither are present, all variables in the input file will be written to the output file.
-
-_Masking options:_
-
-Points on a pressure level grid may fall below ground-level in some fields of the input file. When Heaviside masking is enabled, pressure level data that were located above ground-level for less than the critical time fraction `HCRIT` will be masked.
-
-By default, variables on pressure level grids that fall below-ground level will be masked with the appropriate Heaviside variable found in the input file. If the Heaviside variable cannot be found, these variables will be omitted from the output. This behaviour can be controlled by the following options:
-
-* `--hcrit HCRIT` Minimum fraction of the time spent above ground-level for a pressure grid data point to be considered valid.  Data points in pressure grid variables will be masked if they were above ground-level for less than the critical fraction `HCRIT` of the time. This option has no effect when used together with the `--nomask` option. Default `0.5`.
-* `--nomask` Don't mask variables on pressure level grids. When selected, unmasked pressure level variables will be written to the output file regardless of the presence of the Heaviside variable.
-
-
-_Metadata options:_
-
-* `--model MODEL` Link STASH codes to variable names and metadata using a preset STASHmaster associated with a specific model. Supported options are `cmip6`, `access-cm2`, `access-esm1.5`, and `access-esm1.6`. If omitted, the `cmip6` STASHmaster will be used.
-* `--nohist` Don't add a global history attribute to the output file. When absent, the conversion time, `um2nc` version, and the script location will be added to the `history` global netCDF attribute.
-* `--simple` Use the simple variable naming scheme. Variables in the output file will be named based on their STASH section number and item code, in the format `fld_s<section number>i<item number>`. When absent, variable names will be taken from the selected `STASHmaster` (see the `--model` argument).
-
+Please run
+```
+um2nc convert --help
+```
+for details on the available options for controlling the conversion.
 
 ### `um2nc driver`
 `um2nc` "model drivers" convert UM fields files produced during ACCESS model simulations to netCDF. The drivers find the fields files, convert them, and organise the resulting netCDF files. As each ACCESS model has different requirements for the output format, organisation, and file naming, separate model drivers are used for each model. The model drivers are accessed via the `um2nc driver` command, which is typically run automatically from a script during a model simultion.
 
-**Usage**
-
+Please run
 ```
-um2nc driver [model] [options] model_directory
+um2nc driver --help
 ```
+for detailed usage information for the `um2nc driver` command.
 
-**Positional arguments**
-- `model` Selected model driver to use. Currently available drivers are {`esm1p5`, `esm1p6`}.
-- `model directory` Path to a simulation's output directory. For the `esm1p5` and `esm1p6` drivers, this should be a numbered `payu` `output[0-9][0-9][0-9]` directory.
-
-**Optional Arguments**
-
-* `--help, -h` Display a help message and exit.
-* `--delete-ff, -d`  Delete input files upon successful conversion.
-
-All optional arguments from the `um2nc convert` command for configuring the netCDF conversion are also available for the `um2nc driver` command.
 
 ### Supported files
 

--- a/src/um2nc/cli.py
+++ b/src/um2nc/cli.py
@@ -165,8 +165,8 @@ convert_args.add_argument("outfile", help="Output file")
 driver_args = argparse.ArgumentParser(add_help=False)
 
 driver_args.add_argument(
-    "current_output_dir",
-    help="Output directory to be converted",
+    "model_directory",
+    help="Path to a simulation's output directory containg UM files for conversion",
     type=str
 )
 driver_args.add_argument(
@@ -178,7 +178,14 @@ driver_args.add_argument(
 
 
 # Set up parsers
-parser = argparse.ArgumentParser(prog="um2nc", exit_on_error=False)
+parser = argparse.ArgumentParser(
+    prog="um2nc",
+    exit_on_error=False,
+    description=(
+        "Utilities for converting UM data files to netCDF. Use "
+        "'um2nc {subcommand} --help' for usage information on each subcommand."
+    )
+)
 parser.add_argument(
     "--version","-V",
     action="version",
@@ -188,20 +195,52 @@ parser.add_argument(
 subparsers = parser.add_subparsers(dest="command", required=True)
 
 # convert subcommand
-convert = subparsers.add_parser("convert", parents=[copy.deepcopy(common_args), convert_args],
-                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+convert = subparsers.add_parser(
+    "convert",
+    parents=[copy.deepcopy(common_args), convert_args],
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    description="Convert a single input UM data file to netCDF.",
+    help="Convert a single input UM data file to netCDF."
+)
 # Set defaults which are specific for the convert command
 convert.set_defaults(simple=False, strict=False, verbose=False, model=STASHmaster.DEFAULT.value)
 
 # driver subcommand
-driver = subparsers.add_parser("driver")
+driver = subparsers.add_parser(
+    "driver",
+    help=(
+        "Run a model driver for netCDF conversion during ACCESS model simulations."
+    ),
+    description=(
+        "Run a model driver for automatic UM file to netCDF conversion during "
+        "ACCESS model simulations. Use 'um2nc driver {model_driver} --help' "
+        "for usage information for a specific model driver."
+    )
+)
 
 # esm1p5
 driver_subparsers = driver.add_subparsers(dest="model_driver", required=True)
-esm1p5 = driver_subparsers.add_parser("esm1p5", parents=[copy.deepcopy(common_args), copy.deepcopy(driver_args)],  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+esm1p5 = driver_subparsers.add_parser(
+    "esm1p5",
+    description=(
+        "Model driver for automatic UM file to netCDF conversion "
+        "during ACCESS-ESM1.5 simulations."
+    ),
+    help="Model driver for ACCESS-ESM1.5 netCDF conversion.",
+    parents=[copy.deepcopy(common_args), copy.deepcopy(driver_args)],
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 esm1p5.set_defaults(simple=True, strict=True, verbose=True, model=STASHmaster.ACCESS_ESM1p5.value)
 
-esm1p6 = driver_subparsers.add_parser("esm1p6", parents=[copy.deepcopy(common_args), copy.deepcopy(driver_args)],  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+# esm1p6
+esm1p6 = driver_subparsers.add_parser(
+    "esm1p6",
+    description=(
+        "Model driver for automatic UM file to netCDF conversion "
+        "during ACCESS-ESM1.6 simulations."
+    ),
+    help="Model driver for ACCESS-ESM1.6 netCDF conversion.",
+    parents=[copy.deepcopy(common_args), copy.deepcopy(driver_args)],
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 esm1p6.set_defaults(simple=True, strict=True, verbose=True, model=STASHmaster.ACCESS_ESM1p5.value)
 
 
@@ -209,7 +248,6 @@ model_drivers = {
     "esm1p5":  Esm1p5Driver,
     "esm1p6":  Esm1p6Driver
 }
-
 
 # Keep track of all um2nc subcommands
 all_subcommands = tuple(subparsers.choices.keys())
@@ -240,7 +278,7 @@ def setup_logging(verbose: bool, quiet: bool, strict: bool):
 def parse_args():
     # Allow for the 'convert' command to be ommited by adding it if missing.
     try:
-        args = parser.parse_args()
+        args = parser.parse_args(args=(sys.argv[1:] or ['--help']))
     except argparse.ArgumentError as e:
         if str(e).startswith('argument command: invalid choice:'):
             arg_str = " ".join(sys.argv[1:])
@@ -261,5 +299,5 @@ def main():
     if args.command == "convert":
         process(args.infile, args.outfile, args)
     elif args.command == "driver":
-        driver = model_drivers[args.model_driver](Path(args.current_output_dir))
+        driver = model_drivers[args.model_driver](Path(args.model_directory))
         driver.run_conversion(args.delete_ff, args)

--- a/src/um2nc/cli.py
+++ b/src/um2nc/cli.py
@@ -98,7 +98,7 @@ restrict_group.add_argument(
     nargs="+",
     help=("List of variables to exclude from the output file. Variables are specified by their STASH codes "
           "in the format '1000 * section number + item number'. " 
-          "All other variables present in input file will be written to output file. "
+          "All other variables present in the input file will be written to the output file. "
           "Cannot be used with '--include'.")
 )
 
@@ -184,7 +184,6 @@ driver_args.add_argument(
     "model_directory",
     type=str,
     help=("Path to a simulation's output directory containg UM files for conversion. "
-          "For the 'esm1p5' and 'esm1p6' drivers, this should be a numbered payu output[0-9][0-9][0-9] directory."
           )
 )
 driver_args.add_argument(

--- a/src/um2nc/cli.py
+++ b/src/um2nc/cli.py
@@ -70,14 +70,14 @@ common_args.add_argument(
     required=False,
     type=int,
     default=4,
-    help="Compression level. '0' (none) to '9' (max).",
+    help="NetCDF compression level. '0' (none) to '9' (max).",
 )
 common_args.add_argument(
     "--64",
     dest="use64bit",
     action="store_true",
     default=False,
-    help="Write 64 bit output when input is 64 bit"
+    help="Write 64 bit output when input is 64 bit. When absent, output will be 32 bit."
 )
 
 restrict_group = common_args.add_mutually_exclusive_group()
@@ -86,14 +86,20 @@ restrict_group.add_argument(
     dest="include_list",
     type=int,
     nargs="+",
-    help="List of stash codes to include"
+    help=("List of variables to include in the output file. Variables are specified by their STASH codes "
+          "in the format '1000 * section number + item number'. "
+          "No other variables will be written to the output file. "
+          "Cannot be used with '--exclude'.")
 )
 restrict_group.add_argument(
     "--exclude",
     dest="exclude_list",
     type=int,
     nargs="+",
-    help="List of stash codes to exclude"
+    help=("List of variables to exclude from the output file. Variables are specified by their STASH codes "
+          "in the format '1000 * section number + item number'. " 
+          "All other variables present in input file will be written to output file. "
+          "Cannot be used with '--include'.")
 )
 
 common_args.add_argument(
@@ -101,21 +107,41 @@ common_args.add_argument(
     dest="nomask",
     action="store_true",
     default=False,
-    help="Don't mask variables on pressure level grids.",
-)
-common_args.add_argument(
-    "--nohist",
-    dest="nohist",
-    action="store_true",
-    default=False,
-    help="Don't add/update the global 'history' attribute in the output netCDF."
+    # TODO
+    help=("Data on a pressure level grid may fall below ground level during a simulation. "
+          "By default, um2nc applies a heaviside mask to these points to ensure valid data is written to the "
+          "output, and drops these variables if the mask variable is missing from the input. "
+          "When selected, '--nomask' disables the masking and writes pressure level variables to the "
+          "output without corrections.")
 )
 common_args.add_argument(
     "--hcrit",
     dest="hcrit",
     type=float,
     default=0.5,
-    help="Critical value of the Heaviside variable for pressure level masking."
+    help=("Minimum fraction of the time spent above ground-level for a pressure grid data point "
+          "to be considered valid. Data points in pressure grid variables will be masked if they "
+          "were above ground-level for less than the critical fraction HCRIT of the time. "
+          "This option has no effect when used together with the '--nomask' option."
+    )
+)
+common_args.add_argument(
+    "--model",
+    dest="model",
+    type=STASHmaster,
+    action=EnumAction,
+    help=(
+        "Link STASH codes to variable names and metadata by using a preset STASHmaster associated with a specific model. "
+        f"Options: {[v.value for v in STASHmaster]}. If omitted, the '{STASHmaster.CMIP6.value}' STASHmaster will be used."
+    ),
+)
+common_args.add_argument(
+    "--nohist",
+    dest="nohist",
+    action="store_true",
+    default=False,
+    help=("Don't add a global history attribute to the output file. By default, the conversion time, um2nc version, "
+          "and script location will be added.")
 )
 common_args.add_argument(
     "--simple",
@@ -128,8 +154,8 @@ common_args.add_argument(
     dest="strict",
     action="store_true",
     default=False,
-    help="Promote the StrictWarning class of warnings to errors.")
-
+    help="Promote the StrictWarning class of warnings to errors."
+)
 verbosity_group = common_args.add_mutually_exclusive_group()
 verbosity_group.add_argument(
     "-v", "--verbose",
@@ -145,35 +171,27 @@ verbosity_group.add_argument(
     help="Suppress warnings arising from um2nc."
 )
 
-common_args.add_argument(
-    "--model",
-    dest="model",
-    type=STASHmaster,
-    action=EnumAction,
-    help=(
-        "Link STASH codes to variable names and metadata by using a preset STASHmaster associated with a specific model. "
-        f"Options: {[v.value for v in STASHmaster]}."
-    ),
-)
 
 # Arguments for the convert command
 convert_args = argparse.ArgumentParser(add_help=False)
-convert_args.add_argument("infile", help="Input file")
-convert_args.add_argument("outfile", help="Output file")
+convert_args.add_argument("infile", help="Input UM data file.")
+convert_args.add_argument("outfile", help="Output netCDF file.")
 
 # Arguments shared between model drivers
 driver_args = argparse.ArgumentParser(add_help=False)
 
 driver_args.add_argument(
     "model_directory",
-    help="Path to a simulation's output directory containg UM files for conversion",
-    type=str
+    type=str,
+    help=("Path to a simulation's output directory containg UM files for conversion. "
+          "For the 'esm1p5' and 'esm1p6' drivers, this should be a numbered payu output[0-9][0-9][0-9] directory."
+          )
 )
 driver_args.add_argument(
     "--delete-ff", "-d",
     action="store_true",
     default=False,
-    help="Delete fields files upon successful conversion"
+    help="Delete input files upon successful conversion."
 )
 
 

--- a/src/um2nc/cli.py
+++ b/src/um2nc/cli.py
@@ -107,7 +107,6 @@ common_args.add_argument(
     dest="nomask",
     action="store_true",
     default=False,
-    # TODO
     help=("Data on a pressure level grid may fall below ground level during a simulation. "
           "By default, um2nc applies a heaviside mask to these points to ensure valid data is written to the "
           "output, and drops these variables if the mask variable is missing from the input. "
@@ -183,8 +182,7 @@ driver_args = argparse.ArgumentParser(add_help=False)
 driver_args.add_argument(
     "model_directory",
     type=str,
-    help=("Path to a simulation's output directory containg UM files for conversion. "
-          )
+    help="Path to a simulation's output directory containing UM files for conversion.",
 )
 driver_args.add_argument(
     "--delete-ff", "-d",

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,8 +1,9 @@
 import pytest
 import argparse
-import unittest
+
 
 from enum import Enum
+from unittest import mock
 
 from um2nc.cli import parse_args, EnumAction
 from um2nc.stashmasters import STASHmaster
@@ -13,11 +14,11 @@ def test_parse_args_convert():
     Check that arguments are parsed correctly when the 'convert' command is
     either included or omitted.
     """
-    with unittest.mock.patch("sys.argv", ["um2nc", "input_file", "output_file"]):
+    with mock.patch("sys.argv", ["um2nc", "input_file", "output_file"]):
         with pytest.warns(match="No command recognised among"):
             no_convert_args_out = parse_args()
 
-    with unittest.mock.patch("sys.argv", ["um2nc", "convert", "input_file", "output_file"]):
+    with mock.patch("sys.argv", ["um2nc", "convert", "input_file", "output_file"]):
         convert_args_out = parse_args()
 
     assert no_convert_args_out.command == convert_args_out.command == "convert"
@@ -27,9 +28,20 @@ def test_parse_args_convert():
     assert no_convert_args_out == convert_args_out
 
 
+def test_noargs_help(capsys):
+    """
+    Test that help is shown when no arguments are provided.
+    """
+    with mock.patch("sys.argv", ["um2nc"]):
+        with pytest.raises(SystemExit):
+            parse_args()
+    assert "usage: um2nc" in capsys.readouterr().out
+
+
 @pytest.mark.parametrize(
     "cli_args,expected_defaults",
     [
+
         (
             ["um2nc", "convert", "infile", "outfile"],
             set([
@@ -47,15 +59,24 @@ def test_parse_args_convert():
                 ("verbose", True),
                 ("model", STASHmaster.ACCESS_ESM1p5)
             ])
+        ),
+        (
+            ["um2nc", "driver", "esm1p6", "output_dir"],
+            set([
+                ("simple", True),
+                ("strict", True),
+                ("verbose", True),
+                ("model", STASHmaster.ACCESS_ESM1p5)
+            ])
         )
     ]
 )
 def test_command_defaults(cli_args, expected_defaults):
     """
     Test that different default values are correctly set with the 'convert'
-    and 'driver esm1p5' commands.
+    and 'driver esm1p5' and 'driver esm1p6' commands.
     """
-    with unittest.mock.patch("sys.argv", cli_args):
+    with mock.patch("sys.argv", cli_args):
         args = parse_args()
     args_set = set(vars(args).items())
     assert expected_defaults.issubset(args_set)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -41,7 +41,6 @@ def test_noargs_help(capsys):
 @pytest.mark.parametrize(
     "cli_args,expected_defaults",
     [
-
         (
             ["um2nc", "convert", "infile", "outfile"],
             set([


### PR DESCRIPTION
Closes #235 

With updates to the cli in #221 and #229, the README instructions have fallen out of date. Additionally, the current help text could be made more informative.

This PR updates the README to be accurate to the current code, and adds help text to the cli to make it clearer how to run `um2nc`.

With the changes in this PR, the help text reads as follows:

```
$ um2nc --help


usage: um2nc [-h] [--version] {convert,driver} ...

Utilities for converting UM data files to netCDF. Use 'um2nc {subcommand} --help' for usage information on each subcommand.

positional arguments:
  {convert,driver}
    convert         Convert a single input UM data file to netCDF.
    driver          Run a model driver for netCDF conversion during ACCESS model simulations.

options:
  -h, --help        show this help message and exit
  --version, -V     show program's version number and exit
```

```
$ um2nc convert --help
 um2nc --help
usage: um2nc [-h] [--version] {convert,driver} ...

Utilities for converting UM data files to netCDF. Use 'um2nc {subcommand} --help' for usage information on each subcommand.

positional arguments:
  {convert,driver}
    convert         Convert a single input UM data file to netCDF.
    driver          Run a model driver for netCDF conversion during ACCESS model simulations.

options:
  -h, --help        show this help message and exit
  --version, -V     show program's version number and exit
(um2nc_dev) [sw6175@gadi-login-05 um2nc-standalone]$ um2nc convert --help
usage: um2nc convert [-h] [-f {1,2,3,4}] [-c COMPRESSION] [--64] [--include INCLUDE_LIST [INCLUDE_LIST ...] | --exclude
                     EXCLUDE_LIST [EXCLUDE_LIST ...]] [--nomask] [--nohist] [--hcrit HCRIT] [--simple] [--strict] [-v | -q]
                     [--model {cmip6,access-cm2,access-esm1.5,access-esm1.6}]
                     infile outfile

Convert a single input UM data file to netCDF.

positional arguments:
  infile                Input file
  outfile               Output file

options:
  -h, --help            show this help message and exit
  -f {1,2,3,4}, --format {1,2,3,4}, --nc-format {1,2,3,4}, --k {1,2,3,4}
                        NetCDF output format. Choose among '1' (classic), '2' (64-bit offset),'3' (netCDF-4), '4' (netCDF-4
                        classic). (default: 3)
  -c COMPRESSION, --compression COMPRESSION
                        Compression level. '0' (none) to '9' (max). (default: 4)
  --64                  Write 64 bit output when input is 64 bit (default: False)
  --include INCLUDE_LIST [INCLUDE_LIST ...]
                        List of stash codes to include (default: None)
  --exclude EXCLUDE_LIST [EXCLUDE_LIST ...]
                        List of stash codes to exclude (default: None)
  --nomask              Don't mask variables on pressure level grids. (default: False)
  --nohist              Don't add/update the global 'history' attribute in the output netCDF. (default: False)
  --hcrit HCRIT         Critical value of the Heaviside variable for pressure level masking. (default: 0.5)
  --simple              Write output using simple variable names of format 'fld_s<section number>i<item number>'. (default: False)
  --strict              Promote the StrictWarning class of warnings to errors. (default: False)
  -v, --verbose         Display verbose output. (default: False)
  -q, --quiet           Suppress warnings arising from um2nc. (default: False)
  --model {cmip6,access-cm2,access-esm1.5,access-esm1.6}
                        Link STASH codes to variable names and metadata by using a preset STASHmaster associated with a specific
                        model. Options: ['cmip6', 'access-cm2', 'access-esm1.5', 'access-esm1.6']. (default: cmip6)
```


```
$ um2nc driver --help

usage: um2nc driver [-h] {esm1p5,esm1p6} ...

Run a model driver for automatic UM file to netCDF conversion during ACCESS model simulations. Use 'um2nc driver {model_driver}
--help' for usage information for a specific model driver.

positional arguments:
  {esm1p5,esm1p6}
    esm1p5         Model driver for ACCESS-ESM1.5 netCDF conversion.
    esm1p6         Model driver for ACCESS-ESM1.6 netCDF conversion.

options:
  -h, --help       show this help message and exit
```


```
$ um2nc driver esm1p5 --help

usage: um2nc driver esm1p5 [-h] [-f {1,2,3,4}] [-c COMPRESSION] [--64] [--include INCLUDE_LIST [INCLUDE_LIST ...] | --exclude
                           EXCLUDE_LIST [EXCLUDE_LIST ...]] [--nomask] [--nohist] [--hcrit HCRIT] [--simple] [--strict] [-v | -q]
                           [--model {cmip6,access-cm2,access-esm1.5,access-esm1.6}] [--delete-ff]
                           model_directory

Model driver for automatic UM file to netCDF conversion during ACCESS-ESM1.5 simulations.

positional arguments:
  model_directory       Path to a simulation's output directory containg UM files for conversion

options:
  -h, --help            show this help message and exit
  -f {1,2,3,4}, --format {1,2,3,4}, --nc-format {1,2,3,4}, --k {1,2,3,4}
                        NetCDF output format. Choose among '1' (classic), '2' (64-bit offset),'3' (netCDF-4), '4' (netCDF-4
                        classic). (default: 3)
  -c COMPRESSION, --compression COMPRESSION
                        Compression level. '0' (none) to '9' (max). (default: 4)
  --64                  Write 64 bit output when input is 64 bit (default: False)
  --include INCLUDE_LIST [INCLUDE_LIST ...]
                        List of stash codes to include (default: None)
  --exclude EXCLUDE_LIST [EXCLUDE_LIST ...]
                        List of stash codes to exclude (default: None)
  --nomask              Don't mask variables on pressure level grids. (default: False)
  --nohist              Don't add/update the global 'history' attribute in the output netCDF. (default: False)
  --hcrit HCRIT         Critical value of the Heaviside variable for pressure level masking. (default: 0.5)
  --simple              Write output using simple variable names of format 'fld_s<section number>i<item number>'. (default: True)
  --strict              Promote the StrictWarning class of warnings to errors. (default: True)
  -v, --verbose         Display verbose output. (default: True)
  -q, --quiet           Suppress warnings arising from um2nc. (default: False)
  --model {cmip6,access-cm2,access-esm1.5,access-esm1.6}
                        Link STASH codes to variable names and metadata by using a preset STASHmaster associated with a specific
                        model. Options: ['cmip6', 'access-cm2', 'access-esm1.5', 'access-esm1.6']. (default: access-esm1.5)
  --delete-ff, -d       Delete fields files upon successful conversion (default: False)
```


```
$ um2nc driver esm1p6 --help

usage: um2nc driver esm1p6 [-h] [-f {1,2,3,4}] [-c COMPRESSION] [--64] [--include INCLUDE_LIST [INCLUDE_LIST ...] | --exclude
                           EXCLUDE_LIST [EXCLUDE_LIST ...]] [--nomask] [--nohist] [--hcrit HCRIT] [--simple] [--strict] [-v | -q]
                           [--model {cmip6,access-cm2,access-esm1.5,access-esm1.6}] [--delete-ff]
                           model_directory

Model driver for automatic UM file to netCDF conversion during ACCESS-ESM1.6 simulations.

positional arguments:
  model_directory       Path to a simulation's output directory containg UM files for conversion

options:
  -h, --help            show this help message and exit
  -f {1,2,3,4}, --format {1,2,3,4}, --nc-format {1,2,3,4}, --k {1,2,3,4}
                        NetCDF output format. Choose among '1' (classic), '2' (64-bit offset),'3' (netCDF-4), '4' (netCDF-4
                        classic). (default: 3)
  -c COMPRESSION, --compression COMPRESSION
                        Compression level. '0' (none) to '9' (max). (default: 4)
  --64                  Write 64 bit output when input is 64 bit (default: False)
  --include INCLUDE_LIST [INCLUDE_LIST ...]
                        List of stash codes to include (default: None)
  --exclude EXCLUDE_LIST [EXCLUDE_LIST ...]
                        List of stash codes to exclude (default: None)
  --nomask              Don't mask variables on pressure level grids. (default: False)
  --nohist              Don't add/update the global 'history' attribute in the output netCDF. (default: False)
  --hcrit HCRIT         Critical value of the Heaviside variable for pressure level masking. (default: 0.5)
  --simple              Write output using simple variable names of format 'fld_s<section number>i<item number>'. (default: True)
  --strict              Promote the StrictWarning class of warnings to errors. (default: True)
  -v, --verbose         Display verbose output. (default: True)
  -q, --quiet           Suppress warnings arising from um2nc. (default: False)
  --model {cmip6,access-cm2,access-esm1.5,access-esm1.6}
                        Link STASH codes to variable names and metadata by using a preset STASHmaster associated with a specific
                        model. Options: ['cmip6', 'access-cm2', 'access-esm1.5', 'access-esm1.6']. (default: access-esm1.5)
  --delete-ff, -d       Delete fields files upon successful conversion (default: False)
```