### PR TITLE
Update integration test descriptions

### DIFF
--- a/integration/INTEGRATION_README.md
+++ b/integration/INTEGRATION_README.md
@@ -19,7 +19,7 @@ Options:
                           Options: "full", "intermediate", "light".
                           Default: "intermediate".
     -v    DATA_VERSION    Version of test reference data to use.
-                          Options: "0".
+                          Options: "0", "1".
                           Default: latest release version
 
 ## Data choices

--- a/integration/regression_tests.sh
+++ b/integration/regression_tests.sh
@@ -21,7 +21,7 @@ Options:
                       Options: "full", "intermediate", "light".
                       Default: "intermediate".
 -v    DATA_VERSION    Version of test reference data to use.
-                      Options: "0".
+                      Options: "0", "1".
                       Default: latest release version.
 EOF
 }


### PR DESCRIPTION
Coinciding with https://github.com/ACCESS-NRI/um2nc-standalone/pull/227, version `1` integration test data was copied to `/g/data/vk83/testing/data/um2nc/integration-tests`. This PR adds version 1 to the available options in the descriptions of the integration tests.